### PR TITLE
Update workflow to run on macOS 15

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Ref

## やったこと

- macos-15 ビルドでコンパイルが通るかどうか検証

## Description

- https://github.com/actions/runner-images#available-images
- latest ではない（多分ベータ版）
- Swift Testing が Xcode16+ で利用可能であり、action が失敗する原因になっていた

