### PR TITLE
Fix SparseSet stale handle destroying reused entity slot

### DIFF
--- a/Sources/ECS/Commons/SparseSet.swift
+++ b/Sources/ECS/Commons/SparseSet.swift
@@ -13,14 +13,16 @@ public struct SparseSet<T> {
     var data: [T]
 
     public func value(forEntity entity: Entity) -> T? {
-        guard let i = self.sparse[entity.slot] else { return nil }
-        guard self.dense[i] == entity else { return nil }
+        guard self.sparse.indices.contains(entity.slot),
+              let i = self.sparse[entity.slot],
+              self.dense[i] == entity else { return nil }
         return self.data[i]
     }
 
     public mutating func update(forEntity entity: Entity, _ execute: (inout T) -> ()) {
-        guard let i = self.sparse[entity.slot] else { return }
-        guard self.dense[i].generation == entity.generation else { return }
+        guard self.sparse.indices.contains(entity.slot),
+              let i = self.sparse[entity.slot],
+              self.dense[i] == entity else { return }
         execute(&self.data[i])
     }
 
@@ -42,7 +44,7 @@ public struct SparseSet<T> {
     }
 
     public mutating func pop(entity: Entity) {
-        assert(entity.generation == self.dense[self.sparse[entity.slot]!].generation)
+        guard self.contains(entity) else { return }
         let denseIndexLast = self.dense.count-1
         let removeIndex = self.sparse[entity.slot]!
 
@@ -57,6 +59,6 @@ public struct SparseSet<T> {
     public func contains(_ entity: Entity) -> Bool {
         guard self.sparse.indices.contains(entity.slot) else { return false }
         guard let i = self.sparse[entity.slot] else { return false }
-        return self.dense.indices.contains(i)
+        return self.dense[i] == entity
     }
 }

--- a/Tests/ecs-swiftTests/SparseSetTests.swift
+++ b/Tests/ecs-swiftTests/SparseSetTests.swift
@@ -1,0 +1,123 @@
+//
+//  SparseSetTests.swift
+//
+//
+//  slot 再利用時に stale な Entity ハンドルが別 entity を破壊しないことを検証する.
+//  (issue #165)
+//
+
+import Testing
+@testable import ECS
+
+struct SparseSetTests {
+
+    /// slot を 1 つ確保した空の SparseSet を返す.
+    private func makeSet<T>(slots: Int, of type: T.Type = T.self) -> SparseSet<T> {
+        var set = SparseSet<T>(sparse: [], dense: [], data: [])
+        for _ in 0..<slots {
+            set.allocate()
+        }
+        return set
+    }
+
+    // MARK: - contains
+
+    @Test func containsRejectsStaleGeneration() {
+        var set = makeSet(slots: 1, of: String.self)
+        let gen0 = Entity(slot: 0, generation: 0)
+        let gen1 = Entity(slot: 0, generation: 1)
+
+        set.insert("gen0", withEntity: gen0)
+        set.pop(entity: gen0)          // slot 0 を解放
+        set.insert("gen1", withEntity: gen1) // slot 0 を再利用
+
+        #expect(set.contains(gen1) == true)
+        #expect(set.contains(gen0) == false) // stale ハンドルは false
+    }
+
+    @Test func containsRejectsOutOfRangeSlot() {
+        let set = makeSet(slots: 1, of: String.self)
+        // 確保していない slot を渡してもクラッシュせず false
+        #expect(set.contains(Entity(slot: 5, generation: 0)) == false)
+    }
+
+    // MARK: - value
+
+    @Test func valueRejectsStaleGeneration() {
+        var set = makeSet(slots: 1, of: String.self)
+        let gen0 = Entity(slot: 0, generation: 0)
+        let gen1 = Entity(slot: 0, generation: 1)
+
+        set.insert("gen0", withEntity: gen0)
+        set.pop(entity: gen0)
+        set.insert("gen1", withEntity: gen1)
+
+        #expect(set.value(forEntity: gen1) == "gen1")
+        #expect(set.value(forEntity: gen0) == nil)  // stale ハンドルは nil
+    }
+
+    @Test func valueRejectsOutOfRangeSlot() {
+        let set = makeSet(slots: 1, of: String.self)
+        #expect(set.value(forEntity: Entity(slot: 5, generation: 0)) == nil)
+    }
+
+    // MARK: - update
+
+    @Test func updateIgnoresStaleGeneration() {
+        var set = makeSet(slots: 1, of: String.self)
+        let gen0 = Entity(slot: 0, generation: 0)
+        let gen1 = Entity(slot: 0, generation: 1)
+
+        set.insert("gen0", withEntity: gen0)
+        set.pop(entity: gen0)
+        set.insert("gen1", withEntity: gen1)
+
+        // stale ハンドルでの update は no-op で, 再利用先の値を汚染しない
+        set.update(forEntity: gen0) { $0 = "corrupted" }
+        #expect(set.value(forEntity: gen1) == "gen1")
+
+        set.update(forEntity: gen1) { $0 = "updated" }
+        #expect(set.value(forEntity: gen1) == "updated")
+    }
+
+    @Test func updateIgnoresOutOfRangeSlot() {
+        var set = makeSet(slots: 1, of: String.self)
+        set.insert("live", withEntity: Entity(slot: 0, generation: 0))
+        set.update(forEntity: Entity(slot: 5, generation: 0)) { $0 = "corrupted" }
+        #expect(set.value(forEntity: Entity(slot: 0, generation: 0)) == "live")
+    }
+
+    // MARK: - pop
+
+    @Test func popIsIdempotentForStaleHandle() {
+        var set = makeSet(slots: 1, of: String.self)
+        let gen0 = Entity(slot: 0, generation: 0)
+        let gen1 = Entity(slot: 0, generation: 1)
+
+        set.insert("gen0", withEntity: gen0)
+        set.pop(entity: gen0)
+        set.insert("gen1", withEntity: gen1)
+
+        // stale ハンドルでの pop は no-op. 再利用先の gen1 は削除されない.
+        set.pop(entity: gen0)
+        #expect(set.contains(gen1) == true)
+        #expect(set.value(forEntity: gen1) == "gen1")
+    }
+
+    @Test func popDoesNotCorruptOtherEntities() {
+        var set = makeSet(slots: 3, of: String.self)
+        let a = Entity(slot: 0, generation: 0)
+        let b = Entity(slot: 1, generation: 0)
+        let c = Entity(slot: 2, generation: 0)
+
+        set.insert("a", withEntity: a)
+        set.insert("b", withEntity: b)
+        set.insert("c", withEntity: c)
+
+        set.pop(entity: b)
+
+        #expect(set.contains(b) == false)
+        #expect(set.value(forEntity: a) == "a")
+        #expect(set.value(forEntity: c) == "c")
+    }
+}

--- a/Tests/ecs-swiftTests/StaleHandleReproTests.swift
+++ b/Tests/ecs-swiftTests/StaleHandleReproTests.swift
@@ -1,0 +1,55 @@
+//
+//  StaleHandleReproTests.swift
+//
+//
+//  issue #165 の再現ケース. 修正前は debug ビルドで assertion failure により
+//  テストプロセスごとクラッシュした. 修正後は stale ハンドルでの despawn が
+//  no-op となり, slot を再利用した新しい entity が誤って削除されないことを検証する.
+//
+
+import Testing
+@testable import ECS
+
+private struct ReproMarker: Component { let tag: String }
+
+private final class Box {
+    var entities: [Entity] = []
+    var survivedTags: [String] = []
+}
+
+struct StaleHandleReproTests {
+    @Test func staleHandleDespawnDoesNotDestroyReusedSlot() {
+        let box = Box()
+        let world = World()
+            .addSystem(.startUp) { (commands: Commands) in
+                let e = commands.spawn().addComponent(ReproMarker(tag: "gen0")).id()
+                box.entities.append(e)
+            }
+            .addSystem(.update) { (commands: Commands, time: Resource<CurrentTime>) in
+                switch time.resource.value {
+                case 1:
+                    commands.despawn(entity: box.entities[0]) // (slot: n, gen: 0) を削除
+                case 2:
+                    commands.spawn().addComponent(ReproMarker(tag: "gen1")) // slot 再利用: (slot: n, gen: 1)
+                case 3:
+                    // stale ハンドル (gen: 0) で despawn.
+                    // 修正後は contains が世代不一致を弾き, pop は no-op になる.
+                    commands.despawn(entity: box.entities[0])
+                default:
+                    break
+                }
+            }
+            .addSystem(.postUpdate) { (query: Query<ReproMarker>) in
+                var tags: [String] = []
+                query.update { tags.append($0.tag) }
+                box.survivedTags = tags
+            }
+
+        for t in 0...4 {
+            world.update(currentTime: Double(t))
+        }
+
+        // gen1 の entity は stale despawn の影響を受けず生存している.
+        #expect(box.survivedTags == ["gen1"])
+    }
+}


### PR DESCRIPTION
- ref #165

## 概要

SparseSet.contains は generation を検証せず, slot 再利用後の stale な Entity ハンドルでも true を返していた. その結果 pop が同一 slot を
再利用中の別 entity の行を誤って削除していた (release), もしくは
assert で落ちていた (debug).
