### PR TITLE
Fix #166: backfill late-registered queries and auto-grow SparseSet

### DIFF
--- a/Sources/ECS/Chunk/ChunkStorage+.swift
+++ b/Sources/ECS/Chunk/ChunkStorage+.swift
@@ -34,6 +34,17 @@ extension ChunkStorageRef {
             .add(chunk: chunk)
     }
 
+    /// Chunk を登録し, すでに生存している entity をその Chunk にバックフィルします.
+    ///
+    /// 最初の spawn より後に登録された Query でも既存 entity を認識できるようにするための経路です.
+    /// `entityRecords` には登録時点で生存している全 entity の record を渡します.
+    func addChunk<ChunkType: Chunk>(_ chunk: ChunkType, backfilling entityRecords: [EntityRecordRef]) {
+        self.addChunk(chunk)
+        for entityRecord in entityRecords {
+            chunk.applyCurrentState(entityRecord)
+        }
+    }
+
     func pushSpawned(entityRecord: EntityRecordRef) {
         storage.valueRef(ofType: ChunkEntityInterface.self)!
             .body

--- a/Sources/ECS/Commons/SparseSet.swift
+++ b/Sources/ECS/Commons/SparseSet.swift
@@ -30,11 +30,10 @@ public struct SparseSet<T> {
         }
     }
 
-    public mutating func allocate() {
-        self.sparse.append(nil)
-    }
-
     public mutating func insert(_ value: T, withEntity entity: Entity) {
+        while self.sparse.count <= entity.slot {
+            self.sparse.append(nil)
+        }
         let denseIndex = self.dense.count
         self.sparse[entity.slot] = denseIndex
         self.dense.append(entity)

--- a/Sources/ECS/FilterdQuery/FIlteredQuery.swift
+++ b/Sources/ECS/FilterdQuery/FIlteredQuery.swift
@@ -34,7 +34,7 @@ final public class Filtered<Q: QueryProtocol, F: Filter>: Chunk, SystemParameter
             return
         }
 
-        worldStorage.addChunk(Filtered<Q, F>())
+        worldStorage.chunkStorageRef.addChunk(Filtered<Q, F>(), backfilling: worldStorage.entities.data)
     }
 
     override func applyCurrentState(_ entityRecord: EntityRecordRef) {

--- a/Sources/ECS/FilterdQuery/FIlteredQuery.swift
+++ b/Sources/ECS/FilterdQuery/FIlteredQuery.swift
@@ -9,9 +9,6 @@ final public class Filtered<Q: QueryProtocol, F: Filter>: Chunk, SystemParameter
     let query: Q = Q()
 
     override func spawn(entityRecord: EntityRecordRef) {
-        if entityRecord.entity.generation == 0 {
-            self.query.allocate()
-        }
         guard F.condition(forEntityRecord: entityRecord) else { return }
         self.query.insert(entityRecord: entityRecord)
     }
@@ -37,7 +34,7 @@ final public class Filtered<Q: QueryProtocol, F: Filter>: Chunk, SystemParameter
             return
         }
 
-        worldStorage.chunkStorageRef.addChunk(Filtered<Q, F>())
+        worldStorage.addChunk(Filtered<Q, F>())
     }
 
     override func applyCurrentState(_ entityRecord: EntityRecordRef) {

--- a/Sources/ECS/FilterdQuery/QueryProtocol.swift
+++ b/Sources/ECS/FilterdQuery/QueryProtocol.swift
@@ -9,7 +9,6 @@ public protocol QueryProtocol: Chunk {
     associatedtype Update
     func insert(entityRecord: EntityRecordRef)
     func remove(entity: Entity)
-    func allocate()
     func update( _ f: Update)
     func update(_ entity: Entity, _ f: Update)
     init()

--- a/Sources/ECS/Query/Query.swift
+++ b/Sources/ECS/Query/Query.swift
@@ -10,10 +10,6 @@ final public class Query<C: QueryTarget>: Chunk, SystemParameter {
 
     public override init() {}
 
-    public func allocate() {
-        self.components.allocate()
-    }
-
     public func insert(entityRecord: EntityRecordRef) {
         guard let componentRef = entityRecord.ref(C.self) else { return }
         self.components.insert(componentRef, withEntity: entityRecord.entity)
@@ -25,9 +21,6 @@ final public class Query<C: QueryTarget>: Chunk, SystemParameter {
     }
 
     override func spawn(entityRecord: EntityRecordRef) {
-        if entityRecord.entity.generation == 0 {
-            self.components.allocate()
-        }
         self.insert(entityRecord: entityRecord)
     }
 
@@ -70,7 +63,7 @@ final public class Query<C: QueryTarget>: Chunk, SystemParameter {
 
         let queryRegistory = Self()
 
-        worldStorage.chunkStorageRef.addChunk(queryRegistory)
+        worldStorage.addChunk(queryRegistory)
 
     }
 

--- a/Sources/ECS/Query/Query.swift
+++ b/Sources/ECS/Query/Query.swift
@@ -63,7 +63,7 @@ final public class Query<C: QueryTarget>: Chunk, SystemParameter {
 
         let queryRegistory = Self()
 
-        worldStorage.addChunk(queryRegistory)
+        worldStorage.chunkStorageRef.addChunk(queryRegistory, backfilling: worldStorage.entities.data)
 
     }
 

--- a/Sources/ECS/World/World.swift
+++ b/Sources/ECS/World/World.swift
@@ -43,14 +43,17 @@
 
  */
 final public class World {
-    var entities: SparseSet<EntityRecordRef>
+    /// 生存中の全 entity の台帳. 実体は ``WorldStorageRef/entities`` が保持します.
+    var entities: SparseSet<EntityRecordRef> {
+        get { self.worldStorage.entities }
+        set { self.worldStorage.entities = newValue }
+    }
     var preUpdateSchedule: Schedule
     var updateSchedule: Schedule
     var postUpdateSchedule: Schedule
     public let worldStorage: WorldStorageRef
 
     init(worldStorage: WorldStorageRef) {
-        self.entities = SparseSet(sparse: [], dense: [], data: [])
         self.preUpdateSchedule = .preStartUp
         self.updateSchedule = .startUp
         self.postUpdateSchedule = .postStartUp

--- a/Sources/ECS/World/WorldStorageRef.swift
+++ b/Sources/ECS/World/WorldStorageRef.swift
@@ -14,21 +14,12 @@ final public class WorldStorageRef {
 
     /// World 内で生存している全 entity の台帳.
     ///
-    /// Chunk (Query) の登録時に既存 entity をバックフィルするため, `World` ではなく storage 側で保持します.
+    /// Chunk (Query) 登録時に既存 entity をバックフィルする経路 (`register(to:)`) からは
+    /// `WorldStorageRef` しか辿れないため, `World` ではなく storage 側でこの台帳を保持します.
     var entities = SparseSet<EntityRecordRef>(sparse: [], dense: [], data: [])
 
     // MARK: - public
 
     public let chunkStorageRef = ChunkStorageRef()
     public var additionalStorage = AnyMap<AdditionalStorage>()
-
-    /// Chunk を登録し, すでに生存している全 entity をその Chunk に反映 (バックフィル) します.
-    ///
-    /// これにより, 最初の spawn より後に登録された Query でも既存 entity を認識できます.
-    func addChunk<ChunkType: Chunk>(_ chunk: ChunkType) {
-        self.chunkStorageRef.addChunk(chunk)
-        for entityRecord in self.entities.data {
-            chunk.applyCurrentState(entityRecord)
-        }
-    }
 }

--- a/Sources/ECS/World/WorldStorageRef.swift
+++ b/Sources/ECS/World/WorldStorageRef.swift
@@ -12,8 +12,23 @@ final public class WorldStorageRef {
     var stateStorage = AnyMap<StateStorage>()
     var systemStorage = AnyMap<SystemStorage>()
 
+    /// World 内で生存している全 entity の台帳.
+    ///
+    /// Chunk (Query) の登録時に既存 entity をバックフィルするため, `World` ではなく storage 側で保持します.
+    var entities = SparseSet<EntityRecordRef>(sparse: [], dense: [], data: [])
+
     // MARK: - public
 
     public let chunkStorageRef = ChunkStorageRef()
     public var additionalStorage = AnyMap<AdditionalStorage>()
+
+    /// Chunk を登録し, すでに生存している全 entity をその Chunk に反映 (バックフィル) します.
+    ///
+    /// これにより, 最初の spawn より後に登録された Query でも既存 entity を認識できます.
+    func addChunk<ChunkType: Chunk>(_ chunk: ChunkType) {
+        self.chunkStorageRef.addChunk(chunk)
+        for entityRecord in self.entities.data {
+            chunk.applyCurrentState(entityRecord)
+        }
+    }
 }

--- a/Sources/ECS/WorldMethods/World+Spawn.swift
+++ b/Sources/ECS/WorldMethods/World+Spawn.swift
@@ -15,10 +15,6 @@ extension World {
     /// ``Commands/spawn()`` が実行された後, フレームが終了するタイミングでこの関数が実行されます.
     /// entity へのコンポーネントの登録などは, push の後に行われます.
     func push(entityRecord: EntityRecordRef) {
-        if entityRecord.entity.generation == 0 {
-            self.entities.allocate()
-        }
-
         self.insert(entityRecord: entityRecord)
         self.worldStorage
             .chunkStorageRef

--- a/Sources/ECS_Macros/QueryMacro.swift
+++ b/Sources/ECS_Macros/QueryMacro.swift
@@ -53,10 +53,6 @@ struct QueryMacro: DeclarationMacro {
 
                 public override init() {}
 
-                public func allocate() {
-                    self.components.allocate()
-                }
-
                 public func insert(entityRecord: EntityRecordRef) {
                     guard \(raw: refDeclarationsFromRecord) else { return }
                     self.components.insert((\(raw: refs)), withEntity: entityRecord.entity)
@@ -68,9 +64,6 @@ struct QueryMacro: DeclarationMacro {
                 }
 
                 public override func spawn(entityRecord: EntityRecordRef) {
-                    if entityRecord.entity.generation == 0 {
-                        self.components.allocate()
-                    }
                     self.insert(entityRecord: entityRecord)
                 }
 
@@ -106,7 +99,7 @@ struct QueryMacro: DeclarationMacro {
                 public static func register(to worldStorage: WorldStorageRef) {
                     guard worldStorage.chunkStorageRef.chunk(ofType: Self.self) == nil else { return }
                     let queryRegistory = Self()
-                    worldStorage.chunkStorageRef.addChunk(queryRegistory)
+                    worldStorage.addChunk(queryRegistory)
                 }
 
                 public static func getParameter(from worldStorage: WorldStorageRef) -> Self? {

--- a/Sources/ECS_Macros/QueryMacro.swift
+++ b/Sources/ECS_Macros/QueryMacro.swift
@@ -99,7 +99,7 @@ struct QueryMacro: DeclarationMacro {
                 public static func register(to worldStorage: WorldStorageRef) {
                     guard worldStorage.chunkStorageRef.chunk(ofType: Self.self) == nil else { return }
                     let queryRegistory = Self()
-                    worldStorage.addChunk(queryRegistory)
+                    worldStorage.chunkStorageRef.addChunk(queryRegistory, backfilling: worldStorage.entities.data)
                 }
 
                 public static func getParameter(from worldStorage: WorldStorageRef) -> Self? {

--- a/Tests/ecs-swiftTests/LateQueryReproTests.swift
+++ b/Tests/ecs-swiftTests/LateQueryReproTests.swift
@@ -1,0 +1,44 @@
+//
+//  LateQueryReproTests.swift
+//
+//  Regression tests for issue #166:
+//  spawn 後に登録された Query が既存 entity を認識せず, 次の spawn で index out of range クラッシュする.
+//
+
+import Testing
+import ECS
+
+private struct LateComponent: Component {}
+
+private final class Box { var count = -1 }
+
+struct LateQueryReproTests {
+    @Test func lateRegisteredQueryCrashesOnNextSpawn() {
+        let box = Box()
+        let world = World()
+            .addSystem(.startUp) { (commands: Commands) in
+                commands.spawn().addComponent(LateComponent()) // e0: (slot 0, gen 0)
+            }
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        // spawn 後に新しい Query 型のシステムを追加
+        world.addSystem(.update) { (query: Query<LateComponent>) in
+            var c = 0
+            query.update { _ in c += 1 }
+            box.count = c
+        }
+        world.addSystem(.update) { (commands: Commands, time: Resource<CurrentTime>) in
+            if time.resource.value == 3 {
+                commands.spawn().addComponent(LateComponent()) // e1: (slot 1, gen 0)
+            }
+        }
+        world.update(currentTime: 2)
+        // 既存 entity e0 は遅延登録された Query から見える(バックフィル)
+        #expect(box.count == 1, "late-registered query must see pre-existing entities")
+        world.update(currentTime: 3) // e1 の spawn を sparse に反映してもクラッシュしない
+        world.update(currentTime: 4)
+        // e0 + e1 の 2 件が見えている
+        #expect(box.count == 2, "late-registered query must see entities spawned after registration")
+    }
+}


### PR DESCRIPTION
- ref #166 

## 概要

spawn 後に登録された Query が既存 entity を認識せず、次の spawn で
index out of range クラッシュしていた問題を修正する。
