### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`ecs-swift` is a Bevy-inspired Entity Component System (ECS) library in Swift, targeting game development with SpriteKit/SceneKit. Swift tools version 5.9; platforms macOS 10.15+ / iOS 13+. The only external dependency is swift-syntax (for macros).
+
+## Commands
+
+```sh
+swift build                              # build all targets
+swift test                               # run all tests
+swift test --filter ecs-swiftTests       # run one test target
+swift test --filter WorldTests           # run one XCTestCase class
+swift test --filter WorldTests/testFoo   # run a single test method
+```
+
+CI (GitHub Actions on PRs to `main`/`develop`, plus CircleCI with Xcode 16.4) runs `swift package resolve`, `swift build`, `swift test`. There is no lint configuration.
+
+Tests use **XCTest** (not swift-testing). Shared mocks live in `Tests/ecs-swiftTests/Mocks/`, ordering helpers in `Tests/ecs-swiftTests/Common/`.
+
+## Package layout
+
+Three source targets, declared via the `Module` helper structs in `Package.swift`:
+
+- **ECS** (`Sources/ECS/`) — the core library.
+- **ECS_Macros** (`Sources/ECS_Macros/`) — compiler plugin used by ECS.
+- **PlugIns** (`Sources/PlugIns/`) — one module per plugin (`ECS_Graphic`, `ECS_Keyboard`, `ECS_Mouse`, `ECS_ObjectLink`, `ECS_Scene`, `ECS_Scroll`, `ECS_Touch`), each depending only on ECS. All are exported together as the `PlugIns` library product. Each plugin target has its own test target.
+
+## Core architecture (Sources/ECS/)
+
+### World lifecycle and deferred mutation
+
+`World` (`World/World.swift`) owns entities (`SparseSet<EntityRecordRef>`), the schedules, and `WorldStorageRef` — the central storage hub all subsystems hang off. `World.update()` (`WorldMethods/World+Update.swift`) runs three phases — preUpdate → update → postUpdate — and **applies queued commands after each phase**. This deferred-mutation pattern is the key invariant: structural changes (spawn/despawn/add/remove component) requested during a phase never affect queries within that same phase.
+
+The command flow: systems receive a `Commands` parameter → mutations are queued as `Command`s / `EntityTransaction`s (`Commands/`, `EntityCommands/`) → at phase end, entity transactions are applied, then chunk queues (`ChunkStorageRef.applySpawnedEntityQueue()` / `applyUpdatedEntityQueue()`) propagate changes to every chunk.
+
+### Systems and parameter injection
+
+A system is a plain function whose parameters all conform to `SystemParameter` (`SystemParameter/`). `World.addSystem(schedule, closure)` registers each parameter type (`register(to:)`) and wraps the closure; at execution, each parameter is resolved from `WorldStorageRef` via `getParameter(from:)`. Built-in parameters: `Query`/`Query2...Query10`, `Filtered`, `Commands`, `Resource<T>`, `EventReader<T>`/`EventWriter<T>`, `Removed`.
+
+### Storage: chunks are archetypes
+
+`Chunk` (`Chunk/Chunk.swift`) is the base class for anything that tracks a subset of entities. **Queries themselves are chunks**: `Query<C>` stores a `SparseSet<Ref<C>>` and is notified on spawn/despawn/update, so query iteration is just a dense-set walk with no per-frame matching. `Filtered<Q, F>` wraps a query with `With`/`Without`/`And`/`Or` filters (`FilterdQuery/` — the directory-name typo is tracked in issue #184).
+
+### Schedules and states
+
+`Schedule` (`Schedule/`) identifies when systems run: `.startUp`, `.update`, pre/post variants, `.customSchedule(...)`, and state-associated schedules (`.didEnter`, `.willExit`, `.onUpdate`, `.onPause`, `.onResume`, stack variants). The state machine (`States/`) supports `enter` (replace), `push`/`pop` (stack with pause/resume); during preUpdate, state transitions activate/deactivate their associated schedules for the update phase.
+
+### Events
+
+`EventWriter<T>.send()` queues into an `EventQueue<T>` registered via `World.addEventStreamer(eventType:)`; `EventReader<T>` consumes them, and queues are cleared at frame boundaries (`Event/`). Built-in events: `Spawned` and `Removed` (despawned entities).
+
+### Macros (Sources/ECS_Macros/)
+
+- `@Bundle` — generates `BundleProtocol` conformance for a struct of components.
+- `#Query(N)` / `#System(N)` / `#addSystemForWorld(N)` — generate the `Query2...Query10` / `System2...System15` classes and matching `World.addSystem` overloads. The generated variants live in the ECS target as macro expansion sites (e.g. `Query/MultiParamatersQuery.swift`); changing arity limits means touching both the macro and the expansion sites.
+
+### Plugin pattern
+
+A plugin is simply a `(World) -> ()` function applied via `world.addPlugIn(_:)`. The typical plugin (see `Sources/PlugIns/Mouse/`) registers event streamers and extends `World` with methods that forward platform events (NSEvent, touches, etc.) into the ECS event system. `ECS_Scene` provides an `SKScene` subclass that drives `World.setUp()`/`update()`.
+
+## Conventions
+
+- assertion/precondition messages are written in English; doc comments are written in Japanese.


### PR DESCRIPTION
## Summary

Claude Code 向けのガイドファイル `CLAUDE.md` を追加します。

- ビルド/テストコマンド(`swift build` / `swift test` / `--filter` による単一テスト実行)と CI 構成(GitHub Actions・CircleCI Xcode 16.4、lint 設定なし)
- コアアーキテクチャの全体像:
  - `World.update()` の3フェーズと遅延ミューテーションの不変条件
  - SystemParameter による DI
  - Query 自体が Chunk(アーキタイプ)である点
  - Schedule と State の連携、Event ストリーミング、`#Query(N)` 等のマクロ、`(World) -> ()` としてのプラグインパターン
- 規約(assertion メッセージは英語 / doc コメントは日本語)

`FilterdQuery` の typo は #184 で追跡中である旨を注記しています。

## Test plan

- ドキュメントのみの変更のため、コード・ビルドへの影響なし。