### PR TITLE
[DO NOT MERGE] Spike: Archetype ECS (SoA) 検証実装 (#130)

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/ECS_Swift-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ECS_Swift-Package.xcscheme
@@ -124,6 +124,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Benchmarks"
+               BuildableName = "Benchmarks"
+               BlueprintName = "Benchmarks"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`ecs-swift` is a Swift implementation of the Entity Component System (ECS) pattern, heavily influenced by Rust's [Bevy ECS](https://github.com/bevyengine/bevy). It targets game development on top of SpriteKit/SceneKit. Components are defined as plain Swift **structs** conforming to `Component`; the design is protocol-oriented. Source-level docs and comments are written in **Japanese**. (Source: `README.md`)
+
+## Commands
+
+```sh
+swift build                      # build all targets
+swift test                       # run the full test suite
+swift package resolve            # resolve dependencies (swift-syntax)
+
+# Run one test target
+swift test --filter ecs-swiftTests
+swift test --filter GraphicPlugInTests
+
+# Run a single test type or case (swift-testing / XCTest name)
+swift test --filter ecs-swiftTests.QueryTests
+```
+
+CI (CircleCI, `.circleci/config.yml`) runs `swift package resolve` → `swift build` → `swift test` on macOS with Xcode 16.4.0. Requires Swift 5.9+ (macOS 10.15+, iOS 13+). (Source: `Package.swift`, `.circleci/config.yml`)
+
+## Module layout
+
+- `Sources/ECS` — the core ECS engine (product: `ECS`).
+- `Sources/ECS_Macros` — SwiftSyntax compiler-plugin macros used to code-generate the N-arity variants (see below).
+- `Sources/PlugIns/*` — optional plugins, each its own module and product-member of `PlugIns`: `Graphic2D` (ECS_Graphic), `Keyboard`, `Mouse`, `ObjectLink`, `Scene`, `Scroll`, `Touch`. Each plugin depends only on `ECS`.
+
+Every source module has a matching test target under `Tests/` (e.g. `Tests/ecs-swiftTests` tests `ECS`). Tests use the swift-testing framework (`import Testing`, `@Test`) — see `Tests/ecs-swiftTests/UsageTest.swift` for an end-to-end usage example. (Source: `Package.swift`, test files)
+
+## Core architecture
+
+The central object is `World` (`Sources/ECS/World/World.swift`), a class that owns entities and three schedule slots. All engine state lives in `WorldStorageRef` (`Sources/ECS/World/WorldStorageRef.swift`), which holds separate `AnyMap`-backed stores keyed by type: `chunkStorageRef`, `resourceStorage`, `stateStorage`, `systemStorage`, `eventStorage`, `additionalStorage`, plus a shared `commands`. Passing `World` around a game means passing this one storage ref.
+
+**Systems** are just Swift functions. Their parameters must conform to `SystemParameter` (`Sources/ECS/SystemParameter/SystemParameter.swift`), which defines two static hooks: `register(to:)` (called once at `addSystem`) and `getParameter(from:)` (called each execution to resolve the argument from `WorldStorageRef`). To add a new kind of system argument, conform a type to `SystemParameter` — no changes to the executor are needed. Built-in parameters: `Query<C>`, `Commands`, `Resource<R>`, `State<S>`, `EventReader`/`EventWriter`, and custom `AdditionalStorageElement` types.
+
+**Queries** (`Sources/ECS/Query/Query.swift`) are `Chunk` subclasses that maintain a `SparseSet` of component references. They register themselves into `chunkStorageRef` and are kept in sync as entities spawn/despawn/change via `spawn`/`despawn`/`applyCurrentState`. `Filtered<Query, With<...>>` adds filtering (`Sources/ECS/FilterdQuery/`).
+
+**Commands** (`Sources/ECS/Commands/`, `Sources/ECS/EntityCommands/`) are deferred, not immediate. `commands.spawn()` / `commands.entity(_)` / `commands.despawn(_)` enqueue `EntityTransaction`s and `Command`s. They are flushed during `applyCommandsPhase` (spawn queue → apply commands → updated-entity queue), so component structural changes become visible to all queries at frame end. (Source: `Sources/ECS/WorldMethods/World+Update.swift`)
+
+### Update lifecycle
+
+`World.update(currentTime:)` (`Sources/ECS/WorldMethods/World+Update.swift`) runs three phases, each followed by an `applyCommandsPhase`:
+1. `preUpdatePhase` — runs `.preUpdate` systems, then processes state-machine transition queues (willExit/onPause/onResume/didEnter, and (de)registers state-associated schedules), then flushes events.
+2. `updatePhase` — runs `.update` systems plus systems for currently-active state-associated schedules, then flushes events.
+3. `postUpdatePhase` — runs `.postUpdate` systems, then flushes events.
+
+The first frame (`currentTime: 0`) is a preparation frame and does not execute systems. `setUpWorld()` runs the `.preStartUp`/`.startUp`/`.postStartUp` schedules once. (Source: `World+Update.swift`, `Sources/ECS/Schedule/Schedule.swift`)
+
+### Schedules and States
+
+`Schedule` (`Sources/ECS/Schedule/Schedule.swift`) is a type-erased hashable key. Built-ins: `.preStartUp/.startUp/.postStartUp`, `.preUpdate/.update/.postUpdate`, `.removed`, plus `.customSchedule(_)`. **State-associated** schedules (`.didEnter`/`.willExit`/`.onUpdate`/`.onInactiveUpdate`/`.onStackUpdate`/`.onPause`/`.onResume`) are driven by the state machine (`Sources/ECS/States/`), which supports a state stack (push/pop semantics implied by pause/resume/inactive). Register states with `world.addState(initialState:states:)`.
+
+### Events
+
+Event streaming lives in `Sources/ECS/Event/`. Register a type with `world.addEventStreamer(eventType:)`, send with `world.sendEvent(_)`, consume in systems via `EventReader`/`EventWriter`. There is also a lifecycle `Removed` event for despawned components (`Sources/ECS/Event/Removed/`). Events are queued and drained (`applyEventQueue`) after each lifecycle phase.
+
+## Macros (N-arity code generation)
+
+Because Swift lacks variadic generics here, multi-parameter variants are generated by freestanding declaration macros in `Sources/ECS_Macros` (registered in `ECSMacros.swift`):
+- `#Query(n)` → `QueryN<C0…Cn>` classes (`Sources/ECS/Query/MultiParamatersQuery.swift`, generates 2–10).
+- `#System(n)` → `SystemN` executors and `#addSystemForWorld(n)` → `World.addSystem` overloads (`Sources/ECS/Systems/MultiParametersSystem.swift`, generates 2–15).
+- `@Bundle` → generates `BundleProtocol` conformance for grouping components (`Sources/ECS/Commons/Bundle.swift`).
+
+If you need a query/system with more parameters than currently generated, bump the `#Query(n)`/`#System(n)`/`#addSystemForWorld(n)` count in those files rather than hand-writing the type. When touching macro output, remember the generated code is only visible after a build — verify with `swift build`.
+
+## Conventions
+
+- Reference-wrapper types follow a `…Ref` / `Ref<T>` / `Box<T>` naming pattern for the shared-mutable-state boxes threaded through storage.
+- Type-erased per-type stores use `AnyMap<StorageType>` keyed by `ObjectIdentifier`; entity/component tables use `SparseSet`.
+- Plugins expose their public surface as a free `func somePlugIn(_ world: World)` passed to `world.addPlugIn(_)`, plus `World` extension methods for host integration (e.g. `KeyBoard.swift`'s `keyDown(with:)`). macOS-only plugin code is guarded with `#if os(macOS)`.

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,7 @@ extension Module {
     static let touch = Module(name: "ECS_Touch", path: "Sources/PlugIns/Touch")
 
     static let ecs_swiftTests = Module(name: "ecs-swiftTests")
+    static let benchmarks = Module(name: "Benchmarks")
     static let graphicPlugInTests = Module(name: "GraphicPlugInTests")
     static let keyBoardPlugInTests = Module(name: "KeyBoardPlugInTests")
     static let mousePlugInTests = Module(name: "MousePlugInTests")
@@ -126,6 +127,9 @@ let package = Package(
             dependencies: [.ecs]),
         .testTarget(
             module: .ecs_swiftTests,
+            dependencies: [.ecs]),
+        .testTarget(
+            module: .benchmarks,
             dependencies: [.ecs]),
         .testTarget(
             module: .graphicPlugInTests,

--- a/Sources/ECS/Archetype/Archetype.swift
+++ b/Sources/ECS/Archetype/Archetype.swift
@@ -101,7 +101,10 @@ final class Archetype {
     }
 
     /// `entities.count == columns[i].count`(全 i)の不変条件をデバッグビルドで検証します。
-    private func assertInvariant() {
+    ///
+    /// 行操作を Archetype 外(searched entity 経路の行移動など)で行った場合にも
+    /// 検証できるよう internal にしています。
+    func assertInvariant() {
         assert(
             self.columns.allSatisfy { $0.count == self.entities.count },
             "Archetype row count invariant violated."

--- a/Sources/ECS/Archetype/Archetype.swift
+++ b/Sources/ECS/Archetype/Archetype.swift
@@ -1,0 +1,110 @@
+//
+//  Archetype.swift
+//
+//
+//  Created by rrbox on 2026/07/06.
+//
+
+/// Archetype を識別するキーです。コンポーネント型 ID の集合を表します。
+///
+/// `ids` は常にソート済みであることを不変条件とします。イニシャライザが
+/// 入力をソートするため、同じ型集合からは入力順によらず同一のキーが生成されます。
+struct ArchetypeKey: Hashable {
+    /// ソート済みのコンポーネント型 ID 配列です。
+    let ids: [ComponentTypeID]
+
+    /// 型 ID 配列をソートしてキーを生成します。
+    /// - Parameter ids: コンポーネント型 ID 配列。順序は問いません。
+    init(sorting ids: [ComponentTypeID]) {
+        self.ids = ids.sorted()
+    }
+}
+
+/// 同じコンポーネント型集合を持つ entity 群を SoA レイアウトで保持するテーブルです。
+///
+/// `entities` が行番号 → entity の対応を持ち、`columns` は `key.ids` と並行な
+/// 型消去カラム配列です。行操作は必ず `entities` と全カラムを同期して行い、
+/// `entities.count == columns[i].count`(全 i)を不変条件とします(デバッグビルドの
+/// assertion で検出)。
+///
+/// `addEdges` / `removeEdges` は archetype graph の辺(コンポーネント追加・削除による
+/// 移動先)で、本型では保持のみを担い、構築はストレージ側で行います。
+/// 辺は強参照で保持しますが、Archetype はストレージと同寿命であり回収は行わないため
+/// 許容されます(設計方針)。
+final class Archetype {
+    /// この Archetype の型集合キーです。
+    let key: ArchetypeKey
+
+    /// 行番号 → entity の対応表です。
+    var entities = [Entity]()
+
+    /// `key.ids` と並行なカラム配列です。
+    var columns: [AnyColumn]
+
+    /// コンポーネント型 ID → `columns` 内インデックスの索引です。
+    var columnIndexByType: [ComponentTypeID: Int]
+
+    /// コンポーネント追加時の移動先 Archetype への辺です(archetype graph)。
+    var addEdges = [ComponentTypeID: Archetype]()
+
+    /// コンポーネント削除時の移動先 Archetype への辺です(archetype graph)。
+    var removeEdges = [ComponentTypeID: Archetype]()
+
+    /// キーと、`key.ids` に並行なカラム配列から Archetype を生成します。
+    /// - Parameters:
+    ///   - key: 型集合キー。
+    ///   - columns: `key.ids` と同数・同順のカラム配列。
+    init(key: ArchetypeKey, columns: [AnyColumn]) {
+        assert(key.ids.count == columns.count, "Archetype columns must be parallel to key.ids.")
+        self.key = key
+        self.columns = columns
+        var columnIndexByType = [ComponentTypeID: Int]()
+        for (index, id) in key.ids.enumerated() {
+            columnIndexByType[id] = index
+        }
+        self.columnIndexByType = columnIndexByType
+    }
+
+    /// 指定した型 ID のカラムを返します。
+    /// - Parameter id: コンポーネント型 ID。
+    /// - Returns: 対応するカラム。この Archetype に含まれない型の場合は nil。
+    func column(of id: ComponentTypeID) -> AnyColumn? {
+        guard let index = self.columnIndexByType[id] else { return nil }
+        return self.columns[index]
+    }
+
+    /// 行を追加します。カラムへの値の追加は呼び出し側が `fillColumns` 内で行います。
+    /// - Parameters:
+    ///   - entity: 追加する行の entity。
+    ///   - fillColumns: `key.ids` と並行なカラム配列を受け取り、全カラムへ 1 要素ずつ追加するクロージャ。
+    func appendRow(entity: Entity, fillColumns: ([AnyColumn]) -> Void) {
+        self.entities.append(entity)
+        fillColumns(self.columns)
+        self.assertInvariant()
+    }
+
+    /// 指定した行を swap-remove し、穴を埋めるために移動してきた entity を返します。
+    ///
+    /// `entities` と全カラムを同期して swap-remove します。戻り値は移動後に `row` に
+    /// 位置する entity で、呼び出し側の entity 所在情報(entityIndex)の補正に使用します。
+    /// - Parameter row: 削除する行のインデックス。
+    /// - Returns: `row` を埋めるために末尾から移動してきた entity。削除した行が末尾だった場合は nil。
+    func swapRemoveRow(_ row: Int) -> Entity? {
+        let lastRow = self.entities.count - 1
+        self.entities.swapAt(row, lastRow)
+        self.entities.removeLast()
+        for column in self.columns {
+            column.swapRemoveRow(row)
+        }
+        self.assertInvariant()
+        return row < lastRow ? self.entities[row] : nil
+    }
+
+    /// `entities.count == columns[i].count`(全 i)の不変条件をデバッグビルドで検証します。
+    private func assertInvariant() {
+        assert(
+            self.columns.allSatisfy { $0.count == self.entities.count },
+            "Archetype row count invariant violated."
+        )
+    }
+}

--- a/Sources/ECS/Archetype/ArchetypeStaging.swift
+++ b/Sources/ECS/Archetype/ArchetypeStaging.swift
@@ -1,0 +1,55 @@
+//
+//  ArchetypeStaging.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+/// spawn staging(`EntityRecordRef`)に保持された値を、要素型を知らない呼び出し側から
+/// Archetype のカラムへ挿入できるようにするためのプロトコルです。
+///
+/// `ComponentRef<T>` のみが適合します。`ImmutableRef`(record 内の Entity エントリ)は
+/// 適合させないため、record の map を `ArchetypeInsertable` で列挙すると
+/// Entity エントリは自然にスキップされます。
+protocol ArchetypeInsertable {
+    /// コンポーネント型 `T` を識別するキーです(`ObjectIdentifier(T.self)`)。
+    ///
+    /// record の map のキー、および `ComponentTypeRegistry` の `typeID(for:)` に
+    /// 渡すキーと同じ導出方法で一致させます。
+    var componentTypeKey: ObjectIdentifier { get }
+
+    /// 保持する値の型に対応する空カラム(`Column<T>()`)を生成します。
+    ///
+    /// 新しい Archetype を作成する際のカラムのひな形として使用します。
+    func makeColumnPrototype() -> AnyColumn
+
+    /// 保持している現在値を `column` の末尾へ追加します(行の挿入)。
+    /// - Parameter column: 追加先のカラム。`Column<T>` である必要があります。
+    func appendValue(to column: AnyColumn)
+}
+
+extension ComponentRef: ArchetypeInsertable {
+    var componentTypeKey: ObjectIdentifier {
+        ObjectIdentifier(T.self)
+    }
+
+    func makeColumnPrototype() -> AnyColumn {
+        Column<T>()
+    }
+
+    func appendValue(to column: AnyColumn) {
+        // The downcast is confined here as the erased-insertion counterpart of
+        // Column.moveRow; `column` must be created via makeColumnPrototype()
+        // for the same component type.
+        (column as! Column<T>).append(self._value)
+    }
+}
+
+extension EntityRecordRef {
+    /// record の map から `ArchetypeInsertable` に適合する値(コンポーネントの
+    /// `ComponentRef`)のみを列挙します。Entity エントリ(`ImmutableRef`)は
+    /// 適合しないため含まれません。
+    func archetypeInsertables() -> [ArchetypeInsertable] {
+        self.map.body.values.compactMap { $0 as? ArchetypeInsertable }
+    }
+}

--- a/Sources/ECS/Archetype/ArchetypeStaging.swift
+++ b/Sources/ECS/Archetype/ArchetypeStaging.swift
@@ -26,6 +26,15 @@ protocol ArchetypeInsertable {
     /// 保持している現在値を `column` の末尾へ追加します(行の挿入)。
     /// - Parameter column: 追加先のカラム。`Column<T>` である必要があります。
     func appendValue(to column: AnyColumn)
+
+    /// 保持している現在値を `column` の指定行へ上書きします(既存行の値更新)。
+    ///
+    /// searched entity 経路で「既に持っている型への add 差分」を Archetype 移動なしの
+    /// 値上書きとして適用するために使用します(タスク 6.3)。
+    /// - Parameters:
+    ///   - row: 上書きする行のインデックス。
+    ///   - column: 上書き先のカラム。`Column<T>` である必要があります。
+    func writeValue(at row: Int, in column: AnyColumn)
 }
 
 extension ComponentRef: ArchetypeInsertable {
@@ -42,6 +51,12 @@ extension ComponentRef: ArchetypeInsertable {
         // Column.moveRow; `column` must be created via makeColumnPrototype()
         // for the same component type.
         (column as! Column<T>).append(self._value)
+    }
+
+    func writeValue(at row: Int, in column: AnyColumn) {
+        // Same casting rule as appendValue(to:): `column` must be a Column<T>
+        // for the same component type.
+        (column as! Column<T>).data[row] = self._value
     }
 }
 

--- a/Sources/ECS/Archetype/ArchetypeStaging.swift
+++ b/Sources/ECS/Archetype/ArchetypeStaging.swift
@@ -53,3 +53,43 @@ extension EntityRecordRef {
         self.map.body.values.compactMap { $0 as? ArchetypeInsertable }
     }
 }
+
+extension ArchetypeStorageRef {
+    /// staging record(`EntityRecordRef`)の内容を Archetype へ 1 行として挿入し、
+    /// entity の所在を `entityIndex` に登録します(設計: スポーン変換の挿入手順)。
+    ///
+    /// record の map の列挙順は Dictionary 依存で不定なため、insertable を解決済みの
+    /// `ComponentTypeID` でソートしてから prototypes / 値の追加を行います。
+    /// これにより `ArchetypeKey.ids`(ソート済み)とカラムの並びが常に整列します。
+    /// - Parameter record: 挿入する staging record。
+    func insert(record: EntityRecordRef) {
+        let sortedInsertables = record.archetypeInsertables()
+            .map { (id: self.typeID(for: $0.componentTypeKey), insertable: $0) }
+            .sorted { $0.id < $1.id }
+        let key = ArchetypeKey(sorting: sortedInsertables.map { $0.id })
+        let archetype = self.findOrCreate(
+            key: key,
+            prototypes: sortedInsertables.map { $0.insertable.makeColumnPrototype() }
+        )
+        archetype.appendRow(entity: record.entity) { columns in
+            // columns は key.ids と並行 = sortedInsertables と同順です。
+            for (index, element) in sortedInsertables.enumerated() {
+                element.insertable.appendValue(to: columns[index])
+            }
+        }
+        self.setLocation(
+            EntityLocation(archetype: archetype, row: archetype.entities.count - 1),
+            forEntity: record.entity
+        )
+    }
+
+    /// `spawnStagingQueue` の全 record を挿入し、キューをクリアします。
+    ///
+    /// spawn 適用フェーズ(World 側)から呼ばれる想定です。
+    func applySpawnStaging() {
+        for record in self.spawnStagingQueue {
+            self.insert(record: record)
+        }
+        self.spawnStagingQueue.removeAll()
+    }
+}

--- a/Sources/ECS/Archetype/ArchetypeStorage.swift
+++ b/Sources/ECS/Archetype/ArchetypeStorage.swift
@@ -1,0 +1,122 @@
+//
+//  ArchetypeStorage.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+/// entity の所在(所属 Archetype と行番号)を表します。
+///
+/// `archetype` は `ArchetypeStorageRef` と同寿命の Archetype を参照するため
+/// `unowned` で保持します(空 Archetype の回収は行わない設計方針に依存します)。
+struct EntityLocation {
+    /// entity が所属する Archetype です。
+    unowned let archetype: Archetype
+
+    /// Archetype 内の行番号です。
+    var row: Int
+}
+
+/// 新しい Archetype の生成を購読するオブザーバです。
+///
+/// Query が適合し、生成された Archetype と自身のマッチングを行う想定です。
+/// `ArchetypeStorageRef` はオブザーバを強参照で保持しますが、Query は World と
+/// 同寿命であるため循環の問題はありません(設計方針)。
+protocol ArchetypeObserver: AnyObject {
+    /// 新しい Archetype が生成されたときに呼ばれます。
+    /// - Parameters:
+    ///   - archetype: 生成された Archetype。
+    ///   - storage: 生成元のストレージ。
+    func archetypeCreated(_ archetype: Archetype, storage: ArchetypeStorageRef)
+}
+
+/// Archetype の検索・生成、entity 所在管理、新規 Archetype 通知を担うストレージです。
+///
+/// World ごとに 1 つ保持され、`ComponentTypeID` の採番レジストリもインスタンス単位で
+/// 持ちます(World 間で採番が干渉しないようにするため)。
+final class ArchetypeStorageRef {
+    /// 生成順の Archetype 一覧です。
+    var archetypes = [Archetype]()
+
+    /// 型集合キー → Archetype の索引です。
+    var byKey = [ArchetypeKey: Archetype]()
+
+    /// entity → 所在(Archetype と行番号)の対応表です。
+    var entityIndex = SparseSet<EntityLocation>(sparse: [], dense: [], data: [])
+
+    /// 新規 Archetype 生成の通知先です。
+    var observers = [ArchetypeObserver]()
+
+    /// spawn 待ちの entity record キューです(旧 prespawnedEntityQueue 相当)。
+    var spawnStagingQueue = [EntityRecordRef]()
+
+    /// `ObjectIdentifier` → `ComponentTypeID` の採番レジストリです。
+    private let typeRegistry = ComponentTypeRegistry()
+
+    /// 型キーに対応する `ComponentTypeID` を返します。未登録の場合は新しい ID を採番します。
+    /// - Parameter key: コンポーネント型の `ObjectIdentifier`。
+    /// - Returns: 型キーに対応する `ComponentTypeID`。
+    func typeID(for key: ObjectIdentifier) -> ComponentTypeID {
+        self.typeRegistry.typeID(for: key)
+    }
+
+    /// キーに対応する Archetype を返します。存在しない場合は生成し、オブザーバへ通知します。
+    ///
+    /// 既存の Archetype が見つかった場合、`prototypes` は使用されず破棄されます。
+    /// - Parameters:
+    ///   - key: 型集合キー。
+    ///   - prototypes: `key.ids` と並行な空カラム配列。生成時のみ使用されます。
+    /// - Returns: キーに対応する Archetype。
+    func findOrCreate(key: ArchetypeKey, prototypes: [AnyColumn]) -> Archetype {
+        if let existing = self.byKey[key] {
+            return existing
+        }
+        assert(
+            prototypes.allSatisfy { $0.count == 0 },
+            "Archetype prototypes must be empty columns."
+        )
+        let archetype = Archetype(key: key, columns: prototypes)
+        self.archetypes.append(archetype)
+        self.byKey[key] = archetype
+        for observer in self.observers {
+            observer.archetypeCreated(archetype, storage: self)
+        }
+        return archetype
+    }
+
+    /// entity の所在を返します。
+    ///
+    /// 世代チェックを含みます(要件 1-4): despawn 済み、またはスロットが別世代で
+    /// (再)利用されている entity には nil を返します。世代の照合は
+    /// `SparseSet.value(forEntity:)` が dense に保存した entity と slot + generation の
+    /// 両方で比較することにより行われます。
+    /// - Parameter entity: 所在を調べる entity。
+    /// - Returns: entity の所在。未登録・世代不一致の場合は nil。
+    func location(of entity: Entity) -> EntityLocation? {
+        guard self.entityIndex.contains(entity) else { return nil }
+        return self.entityIndex.value(forEntity: entity)
+    }
+
+    /// entity の所在を登録します。
+    ///
+    /// `SparseSet` の `allocate()` 規約に従い、generation == 0 の entity(新規スロット)は
+    /// sparse 配列を伸ばしてから挿入します(現行実装の spawn 手順を踏襲、設計方針)。
+    /// - Parameters:
+    ///   - location: 登録する所在。
+    ///   - entity: 対象の entity。
+    func setLocation(_ location: EntityLocation, forEntity entity: Entity) {
+        if entity.generation == 0 {
+            self.entityIndex.allocate()
+        }
+        self.entityIndex.insert(location, withEntity: entity)
+    }
+
+    /// entity の所在を削除します(despawn 対応)。
+    ///
+    /// 未登録、または世代が一致しない entity への要求は無視します。
+    /// - Parameter entity: 対象の entity。
+    func removeLocation(of entity: Entity) {
+        guard self.location(of: entity) != nil else { return }
+        self.entityIndex.pop(entity: entity)
+    }
+}

--- a/Sources/ECS/Archetype/ArchetypeStorage.swift
+++ b/Sources/ECS/Archetype/ArchetypeStorage.swift
@@ -50,6 +50,12 @@ final class ArchetypeStorageRef {
     /// spawn 待ちの entity record キューです(旧 prespawnedEntityQueue 相当)。
     var spawnStagingQueue = [EntityRecordRef]()
 
+    /// searched entity への変更差分キューです(旧 updatedEntityQueue 相当)。
+    ///
+    /// applyEnityTransactions で蓄積され、applyCommandsPhase 末尾の diff 適用
+    /// (タスク 6.3)で消費・クリアされます。
+    var diffQueues = [SearchedEntityDiffQueue]()
+
     /// `ObjectIdentifier` → `ComponentTypeID` の採番レジストリです。
     private let typeRegistry = ComponentTypeRegistry()
 

--- a/Sources/ECS/Archetype/ArchetypeStorage.swift
+++ b/Sources/ECS/Archetype/ArchetypeStorage.swift
@@ -119,4 +119,23 @@ final class ArchetypeStorageRef {
         guard self.location(of: entity) != nil else { return }
         self.entityIndex.pop(entity: entity)
     }
+
+    /// entity の行を所属 Archetype から swap-remove し、所在情報を整合させます。
+    ///
+    /// 手順: 所在の取得 → despawn 対象の所在削除 → `swapRemoveRow` → filler
+    /// (穴を埋めた entity)の行番号補正。filler は必ず despawn 対象と別 slot の
+    /// 生存 entity であるため、この順序で entityIndex が互いを上書きすることは
+    /// ありません。filler の補正には `SparseSet.update(forEntity:)` を使用します
+    /// (`insert` は dedupe せず stale エントリが残るため)。
+    ///
+    /// 未登録・世代不一致の entity は no-op です(要件 1-4)。
+    /// - Parameter entity: 削除する entity。
+    func despawn(entity: Entity) {
+        guard let location = self.location(of: entity) else { return }
+        self.removeLocation(of: entity)
+        guard let filler = location.archetype.swapRemoveRow(location.row) else { return }
+        self.entityIndex.update(forEntity: filler) { fillerLocation in
+            fillerLocation.row = location.row
+        }
+    }
 }

--- a/Sources/ECS/Archetype/Column.swift
+++ b/Sources/ECS/Archetype/Column.swift
@@ -1,0 +1,66 @@
+//
+//  Column.swift
+//
+//
+//  Created by rrbox on 2026/07/06.
+//
+
+/// Archetype の 1 コンポーネント型分の列(SoA カラム)を型消去して扱うためのプロトコルです。
+///
+/// Archetype 間のエンティティ移動(行の移動)を、要素型を知らない呼び出し側から
+/// 実行できるようにします。要素型へのダウンキャストは `moveRow(_:to:)` の実装内部に
+/// 閉じ込め、呼び出し側にはキャストを持ち込みません。
+protocol AnyColumn: AnyObject {
+    /// カラムが保持する行数です。
+    var count: Int { get }
+
+    /// 同じ要素型の空カラムを生成します(新しい Archetype のカラム作成用)。
+    func makeEmpty() -> AnyColumn
+
+    /// 指定した行の値を `target` の末尾へ移動し、自身からは swap-remove で取り除きます。
+    /// - Parameters:
+    ///   - row: 移動する行のインデックス。
+    ///   - target: 移動先のカラム。自身と同じ要素型である必要があります。
+    func moveRow(_ row: Int, to target: AnyColumn)
+
+    /// 指定した行を swap-remove(末尾要素と入れ替えて末尾を削除)で破棄します。
+    /// - Parameter row: 破棄する行のインデックス。
+    func swapRemoveRow(_ row: Int)
+}
+
+/// コンポーネント型 `C` の値を連続配置で保持する SoA カラムです。
+///
+/// `Array` の値セマンティクスに乗ることで、クラス参照を含む非トリビアルな
+/// コンポーネント(例: `Graphic<Node>` のような型)も安全に保持・移動できます。
+/// Query のイテレーションでは `&column.data[i]` の形で要素へ直接アクセスします。
+final class Column<C: QueryTarget>: AnyColumn {
+    /// カラムの実データです。行番号がそのまま添字になります。
+    var data = [C]()
+
+    var count: Int {
+        self.data.count
+    }
+
+    /// 末尾に値を追加します(新しい行の挿入)。
+    /// - Parameter value: 追加するコンポーネントの値。
+    func append(_ value: C) {
+        self.data.append(value)
+    }
+
+    func makeEmpty() -> AnyColumn {
+        Column<C>()
+    }
+
+    func moveRow(_ row: Int, to target: AnyColumn) {
+        // 要素型へのダウンキャストはここにのみ存在させ、呼び出し側には持ち込みません。
+        let target = target as! Column<C>
+        target.data.append(self.data[row])
+        self.swapRemoveRow(row)
+    }
+
+    func swapRemoveRow(_ row: Int) {
+        // swapAt(row, row) は許容されるため、末尾行の削除もこの実装で成立します。
+        self.data.swapAt(row, self.data.count - 1)
+        self.data.removeLast()
+    }
+}

--- a/Sources/ECS/Archetype/ColumnAccess.swift
+++ b/Sources/ECS/Archetype/ColumnAccess.swift
@@ -1,0 +1,92 @@
+//
+//  ColumnAccess.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+/// Query のターゲット型 `C` を、Archetype 内のデータ供給元へ解決した結果です(要件 2-6)。
+///
+/// マッチ時(`resolve(in:storage:)`)に 1 回だけダウンキャストしてカラムを保持し、
+/// イテレーション時にはキャストなしで要素へアクセスできるようにします。
+///
+/// `Entity` ターゲットは特別扱いされます: Archetype に `Entity` のカラムは存在しないため、
+/// `.entity` として解決し、読み出しは `archetype.entities` から供給します。書き込みは
+/// 破棄されます(現行 `ImmutableRef` の set no-op と同等のセマンティクス)。
+enum ColumnAccess<C: QueryTarget> {
+    /// 対象型のカラムを保持するケースです。resolve 時に 1 回だけダウンキャストされます。
+    case column(Column<C>)
+
+    /// `C == Entity` のケースです。`archetype.entities` から値を供給します。
+    case entity
+
+    /// `C` が `Entity` ターゲットかどうかを返します。
+    static var isEntity: Bool { C.self == Entity.self }
+
+    /// Archetype 内で `C` のデータ供給元を解決します。
+    ///
+    /// - `C == Entity` の場合は常に `.entity` を返します(Entity カラムは存在しないため)。
+    /// - それ以外は `storage` で型 ID を引き、Archetype 内の対応カラムを `.column` として返します。
+    /// - Parameters:
+    ///   - archetype: 解決対象の Archetype。
+    ///   - storage: 型 ID の採番レジストリを持つストレージ。
+    /// - Returns: 解決結果。Archetype が型 `C` を含まない場合は nil(マッチしない)。
+    static func resolve(in archetype: Archetype, storage: ArchetypeStorageRef) -> ColumnAccess<C>? {
+        if self.isEntity {
+            return .entity
+        }
+        let typeID = storage.typeID(for: ObjectIdentifier(C.self))
+        guard let anyColumn = archetype.column(of: typeID) else { return nil }
+        // 設計方針: 要素型へのダウンキャストはマッチ時のこの 1 回のみ。
+        guard let column = anyColumn as? Column<C> else {
+            assertionFailure("Column type mismatch: expected Column<\(C.self)>.")
+            return nil
+        }
+        return .column(column)
+    }
+
+    /// 保持しているカラムを返します。`.entity` の場合は nil です。
+    ///
+    /// Query のイテレーション(`for i in 0..<count { f(&column.data[i]) }`)で
+    /// 要素へ直接アクセスするための公開経路です。
+    var columnRef: Column<C>? {
+        switch self {
+        case .column(let column):
+            return column
+        case .entity:
+            return nil
+        }
+    }
+
+    /// 指定した行の値を読み出します。
+    ///
+    /// `.column` はカラムの実データから、`.entity` は `archetype.entities` から供給します。
+    /// - Parameters:
+    ///   - row: 行番号。
+    ///   - archetype: `.entity` の供給元となる Archetype。resolve に渡したものと同一である必要があります。
+    /// - Returns: 行の値。
+    func value(at row: Int, in archetype: Archetype) -> C {
+        switch self {
+        case .column(let column):
+            return column.data[row]
+        case .entity:
+            // isEntity(C.self == Entity.self)が保証されているため、このキャストは常に成功します。
+            return archetype.entities[row] as! C
+        }
+    }
+
+    /// 指定した行へ値を書き込みます。
+    ///
+    /// `.entity` への書き込みは破棄されます(現行 `ImmutableRef` の set no-op と同等)。
+    /// - Parameters:
+    ///   - value: 書き込む値。
+    ///   - row: 行番号。
+    func setValue(_ value: C, at row: Int) {
+        switch self {
+        case .column(let column):
+            column.data[row] = value
+        case .entity:
+            break
+        }
+    }
+}

--- a/Sources/ECS/Archetype/ComponentTypeID.swift
+++ b/Sources/ECS/Archetype/ComponentTypeID.swift
@@ -1,0 +1,41 @@
+//
+//  ComponentTypeID.swift
+//
+//
+//  Created by rrbox on 2026/07/06.
+//
+
+/// コンポーネント型を識別する連番 ID です。
+///
+/// `ObjectIdentifier` の代わりに軽量な `Int` で型を識別するためのラッパーで、
+/// Archetype のキー(ソート済み ID 配列)の構成要素として使用します。
+/// ID は `ComponentTypeRegistry` が採番順(登録順)に払い出すため、
+/// `Comparable` の順序は採番順と一致します。
+struct ComponentTypeID: Hashable, Comparable {
+    let value: Int
+
+    static func < (lhs: ComponentTypeID, rhs: ComponentTypeID) -> Bool {
+        lhs.value < rhs.value
+    }
+}
+
+/// `ObjectIdentifier` から `ComponentTypeID` を払い出すレジストリです。
+///
+/// 同じ型キーには常に同じ ID を返し、未登録の型キーには 0 から始まる連番を採番します。
+/// World(将来的には `ArchetypeStorageRef`)ごとにインスタンスを保持する想定で、
+/// グローバルな static 状態にはしません(並列テストで World 間の採番が干渉しないようにするため)。
+final class ComponentTypeRegistry {
+    private var ids = [ObjectIdentifier: ComponentTypeID]()
+
+    /// 型キーに対応する `ComponentTypeID` を返します。未登録の場合は新しい ID を採番します。
+    /// - Parameter key: コンポーネント型の `ObjectIdentifier`。
+    /// - Returns: 型キーに対応する `ComponentTypeID`。
+    func typeID(for key: ObjectIdentifier) -> ComponentTypeID {
+        if let id = self.ids[key] {
+            return id
+        }
+        let id = ComponentTypeID(value: self.ids.count)
+        self.ids[key] = id
+        return id
+    }
+}

--- a/Sources/ECS/Commands/Commands.swift
+++ b/Sources/ECS/Commands/Commands.swift
@@ -25,6 +25,14 @@ final public class Commands: SystemParameter {
     var generator = EntityGenerator()
     var entityTransactions = [EntityTransaction]()
 
+    /// この Commands を保持する `WorldStorageRef` への逆参照です。
+    ///
+    /// `entity(_)` が archetype storage の ON/OFF(`experimentalOptions`)を参照して
+    /// queue 実装を選択するために使用します(design.md World 分岐点)。
+    /// `WorldStorageRef` が Commands を強参照するため、循環を避けて weak で保持します。
+    /// `WorldStorageRef.init` で設定されます。
+    weak var worldStorage: WorldStorageRef?
+
     /// Commands では, World への登録時には何もしません.
     public static func register(to worldStorage: WorldStorageRef) {
 

--- a/Sources/ECS/Commons/ExperimentalWorldOptions.swift
+++ b/Sources/ECS/Commons/ExperimentalWorldOptions.swift
@@ -1,0 +1,17 @@
+//
+//  ExperimentalWorldOptions.swift
+//  ECS_Swift
+//
+//  Created by rrbox on 2026/07/06.
+//
+
+/// 検証用の実行時オプション。
+///
+/// 1ビルド内で World ごとに新旧実装を併存させるための内部機構であり、
+/// ビルドパターン切り替え用の FeatureFlags とは役割を分ける。
+/// 安定後に削除または昇格する。
+struct ExperimentalWorldOptions: OptionSet {
+    let rawValue: UInt8
+
+    static let archetypeStorage = ExperimentalWorldOptions(rawValue: 1 << 0)
+}

--- a/Sources/ECS/EntityCommands/Commands+EntityCommands.swift
+++ b/Sources/ECS/EntityCommands/Commands+EntityCommands.swift
@@ -7,7 +7,16 @@
 
 public extension Commands {
     /// Entity を取得して変更を加えます
+    ///
+    /// archetype storage が ON の World では、変更は record への `EntityCommand` 適用の
+    /// 代わりに差分(`ComponentDiff`)として蓄積され、flush 時に Archetype 移動として
+    /// 適用されます(折衷方針の searched 側)。公開 API はどちらの経路でも同一です(要件 3-2)。
     func entity(_ entity: Entity) -> SearchedEntityCommands {
+        if self.worldStorage?.archetypeStorageRef != nil {
+            let queue = SearchedEntityDiffQueue(entity: entity)
+            self.entityTransactions.append(queue)
+            return SearchedEntityCommands(entity: entity, commandsQueue: queue)
+        }
         let queue = SearchedEntityCommandQueue(entity: entity)
         self.entityTransactions.append(queue)
         return SearchedEntityCommands(entity: entity, commandsQueue: queue)

--- a/Sources/ECS/EntityCommands/EntityCommands/EntityCommands.swift
+++ b/Sources/ECS/EntityCommands/EntityCommands/EntityCommands.swift
@@ -1,12 +1,52 @@
 //
 //  EntityCommands.swift
-//  
+//
 //
 //  Created by rrbox on 2023/08/09.
 //
 
+/// `EntityCommands` の公開メソッドから呼ばれる enqueue フックです。
+///
+/// 公開 API(`addComponent` / `removeComponent(ofType:)` / `addBundle` /
+/// `pushCommand`)を変えずに蓄積先を差し替えるための内部境界です(要件 3-2)。
+/// 旧経路(`EntityCommandQueue`)は現行どおり `EntityCommand` を積み、
+/// 新経路(`SearchedEntityDiffQueue`)は `ComponentDiff` を積みます。
+protocol EntityCommandsQueue: AnyObject {
+    /// コンポーネント追加の enqueue フックです。
+    func enqueue<C: Component>(componentToAdd component: C, forEntity entity: Entity)
+
+    /// コンポーネント削除の enqueue フックです。
+    func enqueue<C: Component>(componentTypeToRemove type: C.Type, forEntity entity: Entity)
+
+    /// bundle 追加の enqueue フックです。
+    func enqueue<B: BundleProtocol>(bundleToAdd bundle: B, forEntity entity: Entity)
+
+    /// カスタム `EntityCommand` の enqueue フックです。
+    func enqueue(customCommand command: EntityCommand)
+}
+
 class EntityCommandQueue: EntityTransaction {
     var queue = [EntityCommand]()
+}
+
+extension EntityCommandQueue: EntityCommandsQueue {
+    // 旧経路のフック実装: 現行どおり EntityCommand を生成して積みます(挙動不変)。
+
+    func enqueue<C: Component>(componentToAdd component: C, forEntity entity: Entity) {
+        self.queue.append(AddComponent(entity: entity, component: component))
+    }
+
+    func enqueue<C: Component>(componentTypeToRemove type: C.Type, forEntity entity: Entity) {
+        self.queue.append(RemoveComponent(entity: entity, componentType: C.self))
+    }
+
+    func enqueue<B: BundleProtocol>(bundleToAdd bundle: B, forEntity entity: Entity) {
+        self.queue.append(AddBundle(entity: entity, bundle: bundle))
+    }
+
+    func enqueue(customCommand command: EntityCommand) {
+        self.queue.append(command)
+    }
 }
 
 final class SpawnedEntityCommandQueue: EntityCommandQueue {
@@ -39,17 +79,46 @@ final class SearchedEntityCommandQueue: EntityCommandQueue {
     }
 }
 
+extension SearchedEntityDiffQueue: EntityCommandsQueue {
+    // 新経路のフック実装: EntityCommand の代わりに ComponentDiff を積みます(要件 3-3)。
+    // 対象 entity は自身が保持しているため、フックの entity 引数は使用しません。
+
+    func enqueue<C: Component>(componentToAdd component: C, forEntity entity: Entity) {
+        self.diffs.append(.add(ComponentRef(value: component)))
+    }
+
+    func enqueue<C: Component>(componentTypeToRemove type: C.Type, forEntity entity: Entity) {
+        self.diffs.append(.remove(ObjectIdentifier(C.self)))
+    }
+
+    func enqueue<B: BundleProtocol>(bundleToAdd bundle: B, forEntity entity: Entity) {
+        // 一時的な空 record に bundle を展開し、エントリを add 差分へ変換します
+        // (`@Bundle` 互換を searched 経路でも維持します)。
+        let record = EntityRecordRef(entity: entity)
+        bundle.addComponent(forEntity: record)
+        for insertable in record.archetypeInsertables() {
+            self.diffs.append(.add(insertable))
+        }
+    }
+
+    func enqueue(customCommand command: EntityCommand) {
+        // カスタム EntityCommand は record を前提とするため、archetype storage ON の
+        // searched 経路では未サポートです(design.md エラーハンドリング)。
+        assertionFailure("Custom EntityCommand is not supported on searched entities with archetype storage.")
+    }
+}
+
 public class EntityCommands {
     let entity: Entity
-    let commandQueue: EntityCommandQueue
+    let commandQueue: EntityCommandsQueue
 
-    init(entity: Entity, commandsQueue: EntityCommandQueue) {
+    init(entity: Entity, commandsQueue: EntityCommandsQueue) {
         self.entity = entity
         self.commandQueue = commandsQueue
     }
 
     public func pushCommand(_ command: EntityCommand) {
-        self.commandQueue.queue.append(command)
+        self.commandQueue.enqueue(customCommand: command)
     }
 
     /// Commands で操作した Entity を受け取ります.
@@ -62,7 +131,7 @@ public class EntityCommands {
     /// - Parameter component: 追加するコンポーネントを指定します.
     /// - Returns: Entity component のビルダーです.
     @discardableResult public func addComponent<ComponentType: Component>(_ component: ComponentType) -> Self {
-        self.pushCommand(AddComponent(entity: self.entity, component: component))
+        self.commandQueue.enqueue(componentToAdd: component, forEntity: self.entity)
         return self
     }
 
@@ -70,12 +139,12 @@ public class EntityCommands {
     /// - Parameter type: 削除する Component の型を指定します.
     /// - Returns: Entity component のビルダーです.
     @discardableResult public func removeComponent<ComponentType: Component>(ofType type: ComponentType.Type) -> Self {
-        self.pushCommand(RemoveComponent(entity: entity, componentType: ComponentType.self))
+        self.commandQueue.enqueue(componentTypeToRemove: ComponentType.self, forEntity: self.entity)
         return self
     }
 
     @discardableResult public func addBundle<T: BundleProtocol>(_ bundle: T) -> Self {
-        self.pushCommand(AddBundle(entity: self.entity, bundle: bundle))
+        self.commandQueue.enqueue(bundleToAdd: bundle, forEntity: self.entity)
         return self
     }
 

--- a/Sources/ECS/EntityCommands/EntityCommands/SearchedEntityCommands.swift
+++ b/Sources/ECS/EntityCommands/EntityCommands/SearchedEntityCommands.swift
@@ -6,7 +6,12 @@
 //
 
 final public class SearchedEntityCommands: EntityCommands {
-    init(entity: Entity, commandsQueue: SearchedEntityCommandQueue) {
+    /// searched entity 用のビルダーを生成します。
+    ///
+    /// 蓄積先の queue は World のオプションにより異なります:
+    /// 旧経路は `SearchedEntityCommandQueue`、archetype storage ON の World では
+    /// `SearchedEntityDiffQueue` が渡されます(要件 3-2。公開 API は共通)。
+    override init(entity: Entity, commandsQueue: EntityCommandsQueue) {
         super.init(entity: entity, commandsQueue: commandsQueue)
     }
 }

--- a/Sources/ECS/EntityCommands/EntityCommands/SearchedEntityDiffQueue.swift
+++ b/Sources/ECS/EntityCommands/EntityCommands/SearchedEntityDiffQueue.swift
@@ -1,0 +1,238 @@
+//
+//  SearchedEntityDiffQueue.swift
+//
+//
+//  Created by rrbox on 2026/07/08.
+//
+
+/// searched entity(`commands.entity(_)`)への 1 コンポーネント分の変更差分です。
+///
+/// archetype storage ON の World では、既存 entity への変更は record 直接操作の
+/// 代わりにこの差分として蓄積され、flush 時に Archetype 移動として適用されます
+/// (折衷方針の searched 側、要件 3-3)。
+enum ComponentDiff {
+    /// コンポーネントの追加です。追加する値そのもの(`ComponentRef<C>`)を保持します。
+    /// 旧経路の `AddComponent<C>` 相当です。
+    case add(ArchetypeInsertable)
+
+    /// コンポーネントの削除です。削除する型のキーを保持します。
+    /// 旧経路の `RemoveComponent<C>` 相当です。
+    case remove(ObjectIdentifier)
+
+    /// この差分が対象とするコンポーネント型のキーです。「後勝ち」正規化の
+    /// 同一型判定に使用します。
+    var componentTypeKey: ObjectIdentifier {
+        switch self {
+        case .add(let insertable):
+            return insertable.componentTypeKey
+        case .remove(let key):
+            return key
+        }
+    }
+}
+
+/// searched entity への変更差分を蓄積するトランザクションキューです
+/// (archetype storage ON 専用。旧経路の `SearchedEntityCommandQueue` 相当)。
+///
+/// `runCommand(in:)`(applyEnityTransactions)では蓄積のみを行い、実際の
+/// Archetype 移動は applyCommandsPhase 末尾の diff 適用で行われます
+/// (design.md システムフロー: 「diff queue は蓄積のみ」)。
+final class SearchedEntityDiffQueue: EntityTransaction {
+    /// 変更対象の entity です。
+    let entity: Entity
+
+    /// 蓄積された差分です。空のままなら flush 時に何も起きません(要件 3-4)。
+    var diffs = [ComponentDiff]()
+
+    init(entity: Entity) {
+        self.entity = entity
+    }
+
+    /// 同一型への重複差分を「後勝ち」で正規化した差分列を返します(要件 3-3)。
+    ///
+    /// 同じ型キーが複数回現れた場合、最後の差分のみが残ります
+    /// (add → remove は remove、remove → add は add)。残った差分の位置は
+    /// 最初の出現位置を保ちますが、正規化後は型キーが互いに異なるため
+    /// 適用結果は順序に依存しません。
+    func normalizedDiffs() -> [ComponentDiff] {
+        var result = [ComponentDiff]()
+        var indexByKey = [ObjectIdentifier: Int]()
+        for diff in self.diffs {
+            if let index = indexByKey[diff.componentTypeKey] {
+                result[index] = diff
+            } else {
+                indexByKey[diff.componentTypeKey] = result.count
+                result.append(diff)
+            }
+        }
+        return result
+    }
+
+    /// diff queue を `ArchetypeStorageRef.diffQueues` へ蓄積します。
+    ///
+    /// 差分が空の場合は何も積みません: `commands.entity(e)` だけを呼んで
+    /// 変更を加えなかった場合、flush で Query 再評価を含む一切の処理が
+    /// 発生しません(要件 3-4)。
+    override func runCommand(in world: World) {
+        guard !self.diffs.isEmpty else { return }
+        world.worldStorage.archetypeStorageRef?.diffQueues.append(self)
+    }
+}
+
+// MARK: - flush 適用 (archetype 移動)
+
+extension ArchetypeStorageRef {
+    /// `diffQueues` の全 diff queue を適用し、キューをクリアします。
+    ///
+    /// applyCommandsPhase 末尾(commands 適用後)から呼ばれます。旧経路の
+    /// `applyUpdatedEntityQueue` と同じ位置で実行することで適用順序を現行踏襲と
+    /// します(要件 1-5)。
+    func applyDiffQueues() {
+        // 適用中(findOrCreate)の observer 通知で diffQueues に触れる実装はないため
+        // snapshot は不要ですが、apply 中の再入を避けるため先に drain します。
+        let queues = self.diffQueues
+        self.diffQueues.removeAll()
+        for queue in queues {
+            self.apply(diffQueue: queue)
+        }
+    }
+
+    /// diff queue 1 件を entity の Archetype 移動として適用します。
+    ///
+    /// 手順(design.md「SearchedEntityDiffQueue」適用): 後勝ち正規化 → `entityIndex`
+    /// 検索(不在は silent skip)→ 差分の分類(既存型への add は行の値上書き、
+    /// 不在型の remove は no-op)→ 目標 Archetype の解決(edge / byKey)→ 共通カラムの
+    /// `moveRow` + 追加分の `appendValue`(削除分は移動対象外)→ swap-remove の filler
+    /// 補正 → 自身の所在更新。
+    private func apply(diffQueue: SearchedEntityDiffQueue) {
+        let diffs = diffQueue.normalizedDiffs()
+
+        // 空 diff は何もしません(要件 3-4)。
+        guard !diffs.isEmpty else { return }
+
+        // despawn 済み・世代不一致の entity への適用は現行の searched 挙動に合わせて
+        // silent skip します(design.md エラーハンドリング)。
+        guard let location = self.location(of: diffQueue.entity) else { return }
+        let source = location.archetype
+
+        // 差分を「構造変更」と「値の上書き」に分類します。正規化済みのため
+        // 同一型の差分は 1 件しか現れません。
+        var newAdds = [(id: ComponentTypeID, insertable: ArchetypeInsertable)]()
+        var removedIDs = Set<ComponentTypeID>()
+        for diff in diffs {
+            let id = self.typeID(for: diff.componentTypeKey)
+            switch diff {
+            case .add(let insertable):
+                if let column = source.column(of: id) {
+                    // 既に持っている型への add は Archetype 移動を伴わない行の値上書きです。
+                    // 移動が発生する場合も、上書き後の値が moveRow で移動先へ運ばれます。
+                    insertable.writeValue(at: location.row, in: column)
+                } else {
+                    newAdds.append((id: id, insertable: insertable))
+                }
+            case .remove:
+                // 持っていない型の remove は no-op です。
+                if source.columnIndexByType[id] != nil {
+                    removedIDs.insert(id)
+                }
+            }
+        }
+
+        // 型集合が変わらない場合(上書きのみ・全て no-op)は移動しません。
+        guard !(newAdds.isEmpty && removedIDs.isEmpty) else { return }
+
+        let target = self.resolveTargetArchetype(from: source, adding: newAdds, removing: removedIDs)
+
+        // カラムの行移動: 共通型は moveRow(swap-remove + 移動先末尾へ追加)、
+        // 削除型は swap-remove のみ(値は破棄)、追加型は移動先へ append します。
+        let row = location.row
+        for (index, id) in source.key.ids.enumerated() {
+            let column = source.columns[index]
+            if removedIDs.contains(id) {
+                column.swapRemoveRow(row)
+            } else {
+                // target は「source − removes + adds」の型集合なので必ずカラムがあります。
+                column.moveRow(row, to: target.column(of: id)!)
+            }
+        }
+        for element in newAdds {
+            element.insertable.appendValue(to: target.column(of: element.id)!)
+        }
+
+        // entities 配列をカラムと同期して swap-remove し、移動先へ追加します。
+        let lastRow = source.entities.count - 1
+        source.entities.swapAt(row, lastRow)
+        source.entities.removeLast()
+        target.entities.append(diffQueue.entity)
+        source.assertInvariant()
+        target.assertInvariant()
+
+        // swap-remove で row を埋めた entity(filler)の所在を補正します。
+        // insert は dedupe せず stale エントリが残るため update を使います
+        // (tasks.md Implementation Notes)。
+        if row < lastRow {
+            let filler = source.entities[row]
+            self.entityIndex.update(forEntity: filler) { fillerLocation in
+                fillerLocation.row = row
+            }
+        }
+
+        // 移動した entity 自身の所在を更新します(同上の理由で insert ではなく update)。
+        let newLocation = EntityLocation(archetype: target, row: target.entities.count - 1)
+        self.entityIndex.update(forEntity: diffQueue.entity) { location in
+            location = newLocation
+        }
+    }
+
+    /// 目標 Archetype を解決します。
+    ///
+    /// 単一コンポーネントの構造変更は archetype graph の辺(`addEdges` / `removeEdges`)で
+    /// O(1) 解決し、辺が未構築の場合は `byKey` / `findOrCreate` で解決してから辺を
+    /// 双方向にキャッシュします(design.md: edge はこのときキャッシュ、要件 5-1)。
+    /// 複数差分の複合移動は辺で表現できないため常に `byKey` / `findOrCreate` で解決します。
+    private func resolveTargetArchetype(
+        from source: Archetype,
+        adding newAdds: [(id: ComponentTypeID, insertable: ArchetypeInsertable)],
+        removing removedIDs: Set<ComponentTypeID>
+    ) -> Archetype {
+        // 単一構造変更: 辺キャッシュの参照。
+        if removedIDs.isEmpty, newAdds.count == 1, let cached = source.addEdges[newAdds[0].id] {
+            return cached
+        }
+        if newAdds.isEmpty, removedIDs.count == 1, let cached = source.removeEdges[removedIDs.first!] {
+            return cached
+        }
+
+        // byKey / findOrCreate フォールバック。
+        let targetIDs = source.key.ids.filter { !removedIDs.contains($0) } + newAdds.map { $0.id }
+        let key = ArchetypeKey(sorting: targetIDs)
+        let target: Archetype
+        if let existing = self.byKey[key] {
+            target = existing
+        } else {
+            // 新規生成時のみ prototypes を構築します。共通型は source のカラムから、
+            // 追加型は insertable から、key.ids と並行になるよう解決します。
+            var prototypeByID = [ComponentTypeID: AnyColumn]()
+            for (index, id) in source.key.ids.enumerated() where !removedIDs.contains(id) {
+                prototypeByID[id] = source.columns[index].makeEmpty()
+            }
+            for element in newAdds {
+                prototypeByID[element.id] = element.insertable.makeColumnPrototype()
+            }
+            // findOrCreate は生成時に observers(Query)へ通知するため、
+            // 新しい Archetype は ON の Query に自動的にマッチします。
+            target = self.findOrCreate(key: key, prototypes: key.ids.map { prototypeByID[$0]! })
+        }
+
+        // 解決した辺のキャッシュ(単一構造変更のみ。双方向に張ります)。
+        if removedIDs.isEmpty, newAdds.count == 1 {
+            source.addEdges[newAdds[0].id] = target
+            target.removeEdges[newAdds[0].id] = source
+        } else if newAdds.isEmpty, removedIDs.count == 1 {
+            let id = removedIDs.first!
+            source.removeEdges[id] = target
+            target.addEdges[id] = source
+        }
+        return target
+    }
+}

--- a/Sources/ECS/FilterdQuery/FIlteredQuery.swift
+++ b/Sources/ECS/FilterdQuery/FIlteredQuery.swift
@@ -32,7 +32,16 @@ final public class Filtered<Q: QueryProtocol, F: Filter>: Chunk, SystemParameter
         worldStorage.chunkStorageRef.chunk(ofType: Filtered<Q, F>.self)
     }
 
+    /// `Filtered` を system parameter として登録します。
+    ///
+    /// 制限: `archetypeStorage` オプションが ON の World では `Filtered` は
+    /// 未サポートです(register 時に debug assertion が発火します)。
     public static func register(to worldStorage: WorldStorageRef) {
+        assert(
+            !worldStorage.experimentalOptions.contains(.archetypeStorage),
+            "Filtered queries are not supported with archetype storage yet."
+        )
+
         guard worldStorage.chunkStorageRef.chunk(ofType: Self.self) == nil else {
             return
         }

--- a/Sources/ECS/Query/Query.swift
+++ b/Sources/ECS/Query/Query.swift
@@ -5,8 +5,39 @@
 //  Created by rrbox on 2023/08/12.
 //
 
+/// Archetype バックエンドでの 1 マッチ(マッチした Archetype と、解決済みのアクセス経路)です。
+///
+/// `archetype` は `ArchetypeStorageRef` と同寿命の Archetype を参照するため
+/// `unowned` で保持します(`EntityLocation` と同じ設計方針)。
+struct ArchetypeMatch<C: QueryTarget> {
+    unowned let archetype: Archetype
+    let access: ColumnAccess<C>
+}
+
 final public class Query<C: QueryTarget>: Chunk, SystemParameter {
     var components = SparseSet<Ref<C>>(sparse: [], dense: [], data: [])
+
+    // MARK: - Archetype バックエンド (archetype storage ON)
+
+    /// マッチ済みの Archetype 一覧です。OFF の World では常に空です。
+    var archetypeMatches = [ArchetypeMatch<C>]()
+
+    /// Archetype バックエンドのストレージです。OFF の World では nil のままです。
+    ///
+    /// `register(to:)` 時に一度だけ設定され、以降どちらのバックエンドで動くかは
+    /// 変わりません(設計方針: バックエンドは register 時に確定)。
+    /// ストレージ側(`observers`)が Query を強参照するため、循環を避けるために
+    /// `unowned` で保持します(両者は World と同寿命です)。
+    unowned var archetypeStorage: ArchetypeStorageRef?
+
+    /// この Query が要求するコンポーネント型キーの一覧です。
+    ///
+    /// `Entity` ターゲットは要求に含めません(全 Archetype にマッチします。要件 2-6)。
+    /// 重複型 assertion(要件 2-8)の検査対象で、1 型の Query では重複は自明に
+    /// 発生しませんが、QueryN(マクロ生成)と同じ形を共有します。
+    static var requiredComponentTypeKeys: [ObjectIdentifier] {
+        ColumnAccess<C>.isEntity ? [] : [ObjectIdentifier(C.self)]
+    }
 
     public override init() {}
 
@@ -48,19 +79,55 @@ final public class Query<C: QueryTarget>: Chunk, SystemParameter {
     }
 
     /// Query で指定した Component を持つ entity を world から取得し, イテレーションします.
+    ///
+    /// バックエンドは register 時に確定しているため, イテレーション経路にオプション分岐は
+    /// ありません: OFF では `archetypeMatches` が, ON では `components` が常に空です.
     public func update(_ f: (inout C) -> ()) {
+        // chunk バックエンド (OFF)
         for ref in self.components.data {
             f(&ref.value)
+        }
+        // Archetype バックエンド (ON)
+        for match in self.archetypeMatches {
+            switch match.access {
+            case .column(let column):
+                // `&data[i]` への直接アクセスのため, 要素ごとの動的ディスパッチはありません(要件 5-2)。
+                for i in column.data.indices {
+                    f(&column.data[i])
+                }
+            case .entity:
+                // Entity ターゲットへの書き込みは破棄されます(要件 2-6)。
+                for row in match.archetype.entities.indices {
+                    var value = match.access.value(at: row, in: match.archetype)
+                    f(&value)
+                }
+            }
         }
     }
 
     public func update(_ entity: Entity, _ f: (inout C) -> ()) {
+        if let storage = self.archetypeStorage {
+            guard let match = self.archetypeRow(of: entity, in: storage) else { return }
+            switch match.access {
+            case .column(let column):
+                f(&column.data[match.row])
+            case .entity:
+                // Entity ターゲットへの書き込みは破棄されます(要件 2-6)。
+                var value = match.access.value(at: match.row, in: match.archetype)
+                f(&value)
+            }
+            return
+        }
         guard let ref = self.components.value(forEntity: entity) else { return }
         f(&ref.value)
     }
 
     public func components(forEntity entity: Entity) -> C? {
-        self.components.value(forEntity: entity)?.value
+        if let storage = self.archetypeStorage {
+            guard let match = self.archetypeRow(of: entity, in: storage) else { return nil }
+            return match.access.value(at: match.row, in: match.archetype)
+        }
+        return self.components.value(forEntity: entity)?.value
     }
 
     public static func register(to worldStorage: WorldStorageRef) {
@@ -70,12 +137,71 @@ final public class Query<C: QueryTarget>: Chunk, SystemParameter {
 
         let queryRegistory = Self()
 
-        worldStorage.chunkStorageRef.addChunk(queryRegistory)
-
+        if let archetypeStorage = worldStorage.archetypeStorageRef {
+            // ON: system parameter として解決できるよう AnyMap への登録のみ行い,
+            // chunk broadcasts(ChunkEntityInterface)は購読しません。
+            worldStorage.chunkStorageRef.storage.push(queryRegistory)
+            queryRegistory.registerArchetypeBackend(archetypeStorage)
+        } else {
+            // OFF: 現行どおり AnyMap への登録 + chunk broadcasts の購読を行います。
+            worldStorage.chunkStorageRef.addChunk(queryRegistory)
+        }
     }
 
     public static func getParameter(from worldStorage: WorldStorageRef) -> Self? {
         worldStorage.chunkStorageRef.chunk(ofType: Self.self)
     }
 
+    // MARK: - Archetype バックエンド internals
+
+    /// Archetype バックエンドを有効化します(register 時に一度だけ呼ばれます)。
+    ///
+    /// オブザーバ登録により以降の Archetype 生成を購読し, 既存の Archetype には
+    /// 遡及マッチを行います。
+    func registerArchetypeBackend(_ storage: ArchetypeStorageRef) {
+        let keys = Self.requiredComponentTypeKeys
+        assert(
+            Set(keys).count == keys.count,
+            "Query does not support duplicated component types."
+        )
+        self.archetypeStorage = storage
+        storage.observers.append(self)
+        for archetype in storage.archetypes {
+            self.matchArchetype(archetype, storage: storage)
+        }
+    }
+
+    /// Archetype とのマッチ判定を行い, マッチすれば `archetypeMatches` へ追加します。
+    ///
+    /// 判定は要求 typeID 集合 ⊆ archetype 型集合(要件 2-1, 2-2)で,
+    /// 1 型の Query では `ColumnAccess.resolve` がそのまま判定を兼ねます
+    /// (`Entity` ターゲットは要求が空のため常にマッチします)。
+    func matchArchetype(_ archetype: Archetype, storage: ArchetypeStorageRef) {
+        guard let access = ColumnAccess<C>.resolve(in: archetype, storage: storage) else { return }
+        self.archetypeMatches.append(ArchetypeMatch(archetype: archetype, access: access))
+    }
+
+    /// entity の所在をマッチ済み Archetype から引き, アクセス経路と行番号を返します。
+    ///
+    /// entity が despawn 済み・世代不一致・この Query の対象型を持たない場合は nil です(要件 2-7)。
+    private func archetypeRow(
+        of entity: Entity,
+        in storage: ArchetypeStorageRef
+    ) -> (archetype: Archetype, access: ColumnAccess<C>, row: Int)? {
+        guard let location = storage.location(of: entity),
+              let match = self.archetypeMatches.first(where: { $0.archetype === location.archetype })
+        else { return nil }
+        return (match.archetype, match.access, location.row)
+    }
+
+}
+
+extension Query: ArchetypeObserver {
+    /// 新しい Archetype の生成通知を受け, マッチ判定を行います。
+    ///
+    /// - Important: `findOrCreate` は `applySpawnStaging` の drain 中にも呼ばれるため,
+    ///   この実装では `spawnStagingQueue` に触れてはいけません(silent drop の原因になります)。
+    func archetypeCreated(_ archetype: Archetype, storage: ArchetypeStorageRef) {
+        self.matchArchetype(archetype, storage: storage)
+    }
 }

--- a/Sources/ECS/World/WorldStorageRef.swift
+++ b/Sources/ECS/World/WorldStorageRef.swift
@@ -12,6 +12,23 @@ final public class WorldStorageRef {
     var stateStorage = AnyMap<StateStorage>()
     var systemStorage = AnyMap<SystemStorage>()
 
+    /// 検証用の実行時オプションです。World の初期化時に確定し、以後変更されません(要件 4-4)。
+    let experimentalOptions: ExperimentalWorldOptions
+
+    /// Archetype ベースの entity ストレージです。
+    ///
+    /// `experimentalOptions` に ``ExperimentalWorldOptions/archetypeStorage`` が
+    /// 含まれる場合のみ生成されます。OFF の場合は nil となり、旧経路からの
+    /// 誤参照をクラッシュとして検出できるようにします(設計方針)。
+    let archetypeStorageRef: ArchetypeStorageRef?
+
+    init(experimentalOptions: ExperimentalWorldOptions = []) {
+        self.experimentalOptions = experimentalOptions
+        self.archetypeStorageRef = experimentalOptions.contains(.archetypeStorage)
+            ? ArchetypeStorageRef()
+            : nil
+    }
+
     // MARK: - public
 
     public let chunkStorageRef = ChunkStorageRef()

--- a/Sources/ECS/World/WorldStorageRef.swift
+++ b/Sources/ECS/World/WorldStorageRef.swift
@@ -27,6 +27,10 @@ final public class WorldStorageRef {
         self.archetypeStorageRef = experimentalOptions.contains(.archetypeStorage)
             ? ArchetypeStorageRef()
             : nil
+
+        // Commands.entity(_) がオプションを参照して queue 実装を選択できるよう
+        // 逆参照(weak)を設定します(design.md World 分岐点)。
+        self.commands.worldStorage = self
     }
 
     // MARK: - public

--- a/Sources/ECS/WorldMethods/World+Init.swift
+++ b/Sources/ECS/WorldMethods/World+Init.swift
@@ -7,7 +7,19 @@
 
 public extension World {
     convenience init() {
-        self.init(worldStorage: WorldStorageRef())
+        self.init(experimentalOptions: [])
+    }
+}
+
+extension World {
+    /// 検証用オプションを指定して World を初期化します。
+    ///
+    /// オプションは ``WorldStorageRef/experimentalOptions`` に `let` として保持され、
+    /// 初期化後に変更できません(要件 4-4)。`archetypeStorage` が ON の場合も
+    /// `setUpChunkBuffer` は実行され、chunk buffer はパラメータレジストリとして
+    /// 維持されます(design.md 分岐点1)。
+    convenience init(experimentalOptions: ExperimentalWorldOptions) {
+        self.init(worldStorage: WorldStorageRef(experimentalOptions: experimentalOptions))
 
         // chunk buffer に chunk entity interface を追加します.
         worldStorage.chunkStorageRef.setUpChunkBuffer()

--- a/Sources/ECS/WorldMethods/World+Spawn.swift
+++ b/Sources/ECS/WorldMethods/World+Spawn.swift
@@ -14,26 +14,45 @@ extension World {
     ///
     /// ``Commands/spawn()`` が実行された後, フレームが終了するタイミングでこの関数が実行されます.
     /// entity へのコンポーネントの登録などは, push の後に行われます.
+    ///
+    /// archetype storage が ON の場合は staging queue へ積むのみで, Archetype への
+    /// 実際の挿入は applyCommandsPhase で行われます(design.md World 分岐点2)。
+    /// entity table への登録と ``Spawned`` イベントの発行は新旧共通です(要件 1-6)。
     func push(entityRecord: EntityRecordRef) {
         if entityRecord.entity.generation == 0 {
             self.entities.allocate()
         }
 
         self.insert(entityRecord: entityRecord)
-        self.worldStorage
-            .chunkStorageRef
-            .pushSpawned(entityRecord: entityRecord)
+        if let archetypeStorage = self.worldStorage.archetypeStorageRef {
+            archetypeStorage.spawnStagingQueue.append(entityRecord)
+        } else {
+            self.worldStorage
+                .chunkStorageRef
+                .pushSpawned(entityRecord: entityRecord)
+        }
         self.sendEvent(Spawned(spawnedEntity: entityRecord.entity))
     }
 
     /// Entity を削除します.
     ///
     /// ``Commands/despawn()`` が実行された後, フレームが終了するタイミングでこの関数が実行されます.
+    ///
+    /// archetype storage が ON の場合は所属 Archetype の行を swap-remove し,
+    /// 穴を埋めた entity の所在(行番号)を補正します(design.md World 分岐点3)。
+    /// archetype storage 層では未登録・世代不一致の entity は no-op です(要件 1-4)。
+    /// なお entity table(``World/remove(entity:)``)側は従来どおり, slot が生存中の世代不一致に対して
+    /// デバッグビルドで assertion が働きます(新旧共通の既存挙動)。
+    /// entity table からの削除と Removed lifecycle への通知は新旧共通です(要件 1-7)。
     func despawn(entity: Entity) {
         self.remove(entity: entity)
-        self.worldStorage
-            .chunkStorageRef
-            .despawn(entity: entity)
+        if let archetypeStorage = self.worldStorage.archetypeStorageRef {
+            archetypeStorage.despawn(entity: entity)
+        } else {
+            self.worldStorage
+                .chunkStorageRef
+                .despawn(entity: entity)
+        }
         self.worldStorage
             .eventStorage
             .removedEventReceiver()?

--- a/Sources/ECS/WorldMethods/World+Update.swift
+++ b/Sources/ECS/WorldMethods/World+Update.swift
@@ -205,9 +205,10 @@ extension World {
 
             self.applyCommands(commands: commands)
 
-            // TODO(タスク 6.3): diffQueues の適用(updated/diff 適用)をここに結線します.
+            // searched entity への変更差分を Archetype 移動として適用します(updated/diff 適用).
             // OFF 経路の applyUpdatedEntityQueue と同じ位置(commands の後)で実行することで
             // 適用順序を現行踏襲とします(要件 1-5).
+            archetypeStorage.applyDiffQueues()
         } else {
             // apply commands の際に push された entity を chunk に割り振ります(spawn).
             self.worldStorage.chunkStorageRef.applySpawnedEntityQueue()

--- a/Sources/ECS/WorldMethods/World+Update.swift
+++ b/Sources/ECS/WorldMethods/World+Update.swift
@@ -183,23 +183,40 @@ extension World {
     }
 
     // 各システムが動いた後に実行される
+    //
+    // archetype storage の ON/OFF で spawn/updated queue の適用先が分岐します
+    // (design.md World 分岐点4)。適用順序(spawn 適用 → commands → updated/diff 適用)は
+    // 新旧共通で現行を踏襲します(要件 1-5)。
     func applyCommandsPhase(_ commands: Commands) {
         // removed event を配信します.
         self.applyRemovedEventQueue()
 
-        // これから spawn する entity を chunk storage 内で enqueue
+        // これから spawn する entity を storage 内で enqueue
         // despawn 登録された entity を削除
         // これから spawn する record に addComponent などのコマンドを実行
-        // セットアップされた record を chunk storage 内で enqueue
+        // (ON: staging record への適用 / OFF: セットアップされた record を chunk storage 内で enqueue)
         self.applyEnityTransactions(commands: commands)
 
-        // apply commands の際に push された entity を chunk に割り振ります(spawn).
-        self.worldStorage.chunkStorageRef.applySpawnedEntityQueue()
+        if let archetypeStorage = self.worldStorage.archetypeStorageRef {
+            // ON: staging record を Archetype へ挿入し, entityIndex に所在を登録します(spawn 適用).
+            // record へのコマンド適用は直前の applyEnityTransactions で完了しているため,
+            // 挿入時点で spawn コマンドのコンポーネントはすべて揃っています.
+            archetypeStorage.applySpawnStaging()
 
-        self.applyCommands(commands: commands)
+            self.applyCommands(commands: commands)
 
-        // world 内の entity のコンポーネントの追加/削除.
-        // 同じフレーム内で entity の変更を world 全体に適用するために一番最後に再度実行.
-        self.worldStorage.chunkStorageRef.applyUpdatedEntityQueue()
+            // TODO(タスク 6.3): diffQueues の適用(updated/diff 適用)をここに結線します.
+            // OFF 経路の applyUpdatedEntityQueue と同じ位置(commands の後)で実行することで
+            // 適用順序を現行踏襲とします(要件 1-5).
+        } else {
+            // apply commands の際に push された entity を chunk に割り振ります(spawn).
+            self.worldStorage.chunkStorageRef.applySpawnedEntityQueue()
+
+            self.applyCommands(commands: commands)
+
+            // world 内の entity のコンポーネントの追加/削除.
+            // 同じフレーム内で entity の変更を world 全体に適用するために一番最後に再度実行.
+            self.worldStorage.chunkStorageRef.applyUpdatedEntityQueue()
+        }
     }
 }

--- a/Sources/ECS_Macros/QueryMacro.swift
+++ b/Sources/ECS_Macros/QueryMacro.swift
@@ -46,10 +46,82 @@ struct QueryMacro: DeclarationMacro {
             partialResult.append("c\(i), ")
         }.dropLast(2)
 
+        // MARK: Archetype バックエンド用の生成部品
+
+        let accessTupleTypes = (0..<n).map {
+            "ColumnAccess<C\($0)>"
+        }.joined(separator: ", ")
+        let requiredKeyAppends = (0..<n).map {
+            "if !ColumnAccess<C\($0)>.isEntity { keys.append(ObjectIdentifier(C\($0).self)) }"
+        }.joined(separator: "\n        ")
+        let columnBindings = (0..<n).map {
+            "case .column(let column\($0)) = match.access.\($0)"
+        }.joined(separator: ",\n               ")
+        let columnArgs = (0..<n).map {
+            "&column\($0).data[row]"
+        }.joined(separator: ", ")
+        let rowValueDeclarations = (0..<n).map {
+            "var value\($0) = match.access.\($0).value(at: row, in: match.archetype)"
+        }.joined(separator: "\n                    ")
+        let valueArgs = (0..<n).map {
+            "&value\($0)"
+        }.joined(separator: ", ")
+        let rowValueWriteBacks = (0..<n).map {
+            "match.access.\($0).setValue(value\($0), at: row)"
+        }.joined(separator: "\n                    ")
+        let matchRowValueDeclarations = (0..<n).map {
+            "var value\($0) = match.access.\($0).value(at: match.row, in: match.archetype)"
+        }.joined(separator: "\n            ")
+        let matchRowValueWriteBacks = (0..<n).map {
+            "match.access.\($0).setValue(value\($0), at: match.row)"
+        }.joined(separator: "\n            ")
+        let matchRowValues = (0..<n).map {
+            "match.access.\($0).value(at: match.row, in: match.archetype)"
+        }.joined(separator: ", ")
+        let resolveBindings = (0..<n).map {
+            "let access\($0) = ColumnAccess<C\($0)>.resolve(in: archetype, storage: storage)"
+        }.joined(separator: ",\n              ")
+        let accessValues = (0..<n).map {
+            "access\($0)"
+        }.joined(separator: ", ")
+
         return [
             """
-            final public class Query\(raw: n)<\(raw: genericArguments)>: Chunk, SystemParameter, QueryProtocol {
+            /// Archetype バックエンドでの 1 マッチ(マッチした Archetype と、解決済みのアクセス経路)です。
+            ///
+            /// `archetype` は `ArchetypeStorageRef` と同寿命の Archetype を参照するため
+            /// `unowned` で保持します(`EntityLocation` と同じ設計方針)。
+            struct ArchetypeMatch\(raw: n)<\(raw: genericArguments)> {
+                unowned let archetype: Archetype
+                let access: (\(raw: accessTupleTypes))
+            }
+            """,
+            """
+            final public class Query\(raw: n)<\(raw: genericArguments)>: Chunk, SystemParameter, QueryProtocol, ArchetypeObserver {
                 public var components = SparseSet<(\(raw: refTypes))>(sparse: [], dense: [], data: [])
+
+                // MARK: - Archetype バックエンド (archetype storage ON)
+
+                /// マッチ済みの Archetype 一覧です。OFF の World では常に空です。
+                var archetypeMatches = [ArchetypeMatch\(raw: n)<\(raw: valueTypes)>]()
+
+                /// Archetype バックエンドのストレージです。OFF の World では nil のままです。
+                ///
+                /// `register(to:)` 時に一度だけ設定され、以降どちらのバックエンドで動くかは
+                /// 変わりません(設計方針: バックエンドは register 時に確定)。
+                /// ストレージ側(`observers`)が Query を強参照するため、循環を避けるために
+                /// `unowned` で保持します(両者は World と同寿命です)。
+                unowned var archetypeStorage: ArchetypeStorageRef?
+
+                /// この Query が要求するコンポーネント型キーの一覧です。
+                ///
+                /// `Entity` ターゲットは要求に含めません(全 Archetype にマッチします。要件 2-6)。
+                /// 重複型 assertion(要件 2-8)の検査対象です。
+                static var requiredComponentTypeKeys: [ObjectIdentifier] {
+                    var keys = [ObjectIdentifier]()
+                    \(raw: requiredKeyAppends)
+                    return keys
+                }
 
                 public override init() {}
 
@@ -87,18 +159,53 @@ struct QueryMacro: DeclarationMacro {
                     self.components.insert((\(raw: refs)), withEntity: entityRecord.entity)
                 }
 
+                /// Query で指定した Component を持つ entity を world から取得し, イテレーションします.
+                ///
+                /// バックエンドは register 時に確定しているため, イテレーション経路にオプション分岐は
+                /// ありません: OFF では `archetypeMatches` が, ON では `components` が常に空です.
                 public func update(_ f: (\(raw: parameters)) -> ()) {
+                    // chunk バックエンド (OFF)
                     self.components.data.forEach { components in
                         f(\(raw: componentRefs))
+                    }
+                    // Archetype バックエンド (ON)
+                    for match in self.archetypeMatches {
+                        if \(raw: columnBindings) {
+                            // 全ターゲットが column の経路: `&data[i]` への直接アクセスのため,
+                            // 要素ごとの動的ディスパッチはありません(要件 5-2)。
+                            for row in match.archetype.entities.indices {
+                                f(\(raw: columnArgs))
+                            }
+                        } else {
+                            // Entity ターゲットを含む経路: Entity は `archetype.entities` から供給され,
+                            // Entity への書き込みは破棄されます(要件 2-6)。
+                            for row in match.archetype.entities.indices {
+                                \(raw: rowValueDeclarations)
+                                f(\(raw: valueArgs))
+                                \(raw: rowValueWriteBacks)
+                            }
+                        }
                     }
                 }
 
                 public func update(_ entity: Entity, _ f: (\(raw: parameters)) -> ()) {
+                    if let storage = self.archetypeStorage {
+                        guard let match = self.archetypeRow(of: entity, in: storage) else { return }
+                        // Entity ターゲットへの書き込みは破棄されます(要件 2-6)。
+                        \(raw: matchRowValueDeclarations)
+                        f(\(raw: valueArgs))
+                        \(raw: matchRowValueWriteBacks)
+                        return
+                    }
                     guard let components = self.components.value(forEntity: entity) else { return }
                     f(\(raw: componentRefs))
                 }
 
                 public func components(forEntity entity: Entity) -> (\(raw: valueTypes))? {
+                    if let storage = self.archetypeStorage {
+                        guard let match = self.archetypeRow(of: entity, in: storage) else { return nil }
+                        return (\(raw: matchRowValues))
+                    }
                     guard let components = components.value(forEntity: entity) else { return nil }
                     return (\(raw: componentValuess))
                 }
@@ -106,11 +213,73 @@ struct QueryMacro: DeclarationMacro {
                 public static func register(to worldStorage: WorldStorageRef) {
                     guard worldStorage.chunkStorageRef.chunk(ofType: Self.self) == nil else { return }
                     let queryRegistory = Self()
-                    worldStorage.chunkStorageRef.addChunk(queryRegistory)
+                    if let archetypeStorage = worldStorage.archetypeStorageRef {
+                        // ON: system parameter として解決できるよう AnyMap への登録のみ行い,
+                        // chunk broadcasts(ChunkEntityInterface)は購読しません。
+                        worldStorage.chunkStorageRef.storage.push(queryRegistory)
+                        queryRegistory.registerArchetypeBackend(archetypeStorage)
+                    } else {
+                        // OFF: 現行どおり AnyMap への登録 + chunk broadcasts の購読を行います。
+                        worldStorage.chunkStorageRef.addChunk(queryRegistory)
+                    }
                 }
 
                 public static func getParameter(from worldStorage: WorldStorageRef) -> Self? {
                     worldStorage.chunkStorageRef.chunk(ofType: Self.self)
+                }
+
+                // MARK: - Archetype バックエンド internals
+
+                /// Archetype バックエンドを有効化します(register 時に一度だけ呼ばれます)。
+                ///
+                /// オブザーバ登録により以降の Archetype 生成を購読し, 既存の Archetype には
+                /// 遡及マッチを行います。
+                func registerArchetypeBackend(_ storage: ArchetypeStorageRef) {
+                    let keys = Self.requiredComponentTypeKeys
+                    assert(
+                        Set(keys).count == keys.count,
+                        "Query does not support duplicated component types."
+                    )
+                    self.archetypeStorage = storage
+                    storage.observers.append(self)
+                    for archetype in storage.archetypes {
+                        self.matchArchetype(archetype, storage: storage)
+                    }
+                }
+
+                /// Archetype とのマッチ判定を行い, マッチすれば `archetypeMatches` へ追加します。
+                ///
+                /// 判定は要求 typeID 集合 ⊆ archetype 型集合(要件 2-1, 2-2)で,
+                /// 全ターゲットの `ColumnAccess.resolve` が成功することがそのまま判定を兼ねます
+                /// (`Entity` ターゲットは常に解決されます。要件 2-6)。型集合ベースの判定のため,
+                /// 型引数の順序はマッチ結果に影響しません(要件 2-3)。
+                func matchArchetype(_ archetype: Archetype, storage: ArchetypeStorageRef) {
+                    guard \(raw: resolveBindings)
+                    else { return }
+                    self.archetypeMatches.append(
+                        ArchetypeMatch\(raw: n)(archetype: archetype, access: (\(raw: accessValues)))
+                    )
+                }
+
+                /// entity の所在をマッチ済み Archetype から引き, アクセス経路と行番号を返します。
+                ///
+                /// entity が despawn 済み・世代不一致・この Query の対象型を持たない場合は nil です(要件 2-7)。
+                private func archetypeRow(
+                    of entity: Entity,
+                    in storage: ArchetypeStorageRef
+                ) -> (archetype: Archetype, access: (\(raw: accessTupleTypes)), row: Int)? {
+                    guard let location = storage.location(of: entity),
+                          let match = self.archetypeMatches.first(where: { $0.archetype === location.archetype })
+                    else { return nil }
+                    return (match.archetype, match.access, location.row)
+                }
+
+                /// 新しい Archetype の生成通知を受け, マッチ判定を行います(`ArchetypeObserver`)。
+                ///
+                /// - Important: `findOrCreate` は `applySpawnStaging` の drain 中にも呼ばれるため,
+                ///   この実装では `spawnStagingQueue` に触れてはいけません(silent drop の原因になります)。
+                func archetypeCreated(_ archetype: Archetype, storage: ArchetypeStorageRef) {
+                    self.matchArchetype(archetype, storage: storage)
                 }
             }
             """

--- a/Tests/Benchmarks/ArchetypeBenchmarks.swift
+++ b/Tests/Benchmarks/ArchetypeBenchmarks.swift
@@ -317,6 +317,7 @@ struct ArchetypeBenchmarks {
         }
 
         // 準備フレーム: system は実行されず、spawn の flush のみ行われます(計測区間外)。
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         // 計測対象: 100 フレームの update ループ。
@@ -366,6 +367,7 @@ struct ArchetypeBenchmarks {
         let commands = world.worldStorage.commands
 
         // 準備フレーム(計測区間外)。
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         return measureMilliseconds {
@@ -423,6 +425,7 @@ struct ArchetypeBenchmarks {
         }
 
         // 準備フレーム: spawn の flush(計測区間外)。
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         return measureMilliseconds {

--- a/Tests/Benchmarks/ArchetypeBenchmarks.swift
+++ b/Tests/Benchmarks/ArchetypeBenchmarks.swift
@@ -1,0 +1,436 @@
+//
+//  ArchetypeBenchmarks.swift
+//
+//
+//  Created by rrbox on 2026/07/11.
+//
+
+import Foundation
+@testable import ECS
+import Testing
+
+// MARK: - 実行ゲート
+
+/// ベンチマークの実行可否です。
+///
+/// CI(plain `swift test`)ではこのターゲットもビルド・実行対象になるため、
+/// 環境変数でゲートして CI では skip(即 return)します(design.md「CI には含めない」)。
+/// 手動実行時のみ以下で計測します:
+///
+/// ```sh
+/// RUN_BENCHMARKS=1 swift test -c release --filter Benchmarks
+/// ```
+private var benchmarksEnabled: Bool {
+    ProcessInfo.processInfo.environment["RUN_BENCHMARKS"] == "1"
+}
+
+// MARK: - 計測パラメータ
+
+/// 比較対象の entity 数です(design.md: 10^3 / 10^4 / 10^5)。
+private let entityCounts = [1_000, 10_000, 100_000]
+
+/// 1 計測点あたりの実行回数です。中央値を採用します(tasks.md 8.3: 複数回実行の中央値)。
+private let benchmarkRuns = 5
+
+// MARK: - 計測ヘルパ
+
+/// `body` の実行時間をミリ秒で返します(`ContinuousClock` による手動計測、
+/// design.md「Benchmarks ターゲット」)。
+///
+/// `ContinuousClock` は macOS 13+ / iOS 16+ のため `#available` で分岐します。
+/// ベンチマークは手動実行専用であり、旧 OS では実行しない前提です。
+private func measureMilliseconds(_ body: () -> Void) -> Double {
+    if #available(macOS 13.0, iOS 16.0, *) {
+        let duration = ContinuousClock().measure(body)
+        let (seconds, attoseconds) = duration.components
+        return Double(seconds) * 1_000 + Double(attoseconds) / 1e15
+    } else {
+        fatalError("Benchmarks require macOS 13.0+ / iOS 16.0+ (ContinuousClock).")
+    }
+}
+
+/// ミリ秒値の表示用フォーマットです。
+private func formatMilliseconds(_ value: Double) -> String {
+    String(format: "%.3f", value)
+}
+
+/// `run`(1 回分の計測。戻り値はミリ秒)を `runs` 回実行し、中央値を print して返します。
+///
+/// world の構築などのセットアップは `run` の内部で行い、計測区間
+/// (`measureMilliseconds`)から除外します。
+private func measureMedian(label: String, runs: Int = benchmarkRuns, of run: () -> Double) -> Double {
+    precondition(runs > 0, "runs must be positive.")
+    var samples = [Double]()
+    samples.reserveCapacity(runs)
+    for _ in 0..<runs {
+        samples.append(run())
+    }
+    samples.sort()
+    let median = samples[samples.count / 2]
+    print("\(label): median=\(formatMilliseconds(median))ms (runs=\(runs))")
+    return median
+}
+
+/// 同一シナリオを新旧両バックエンドで計測し、比較行を print します。
+///
+/// 出力例: `scenario1 iteration N=1000 frames=100 legacy=1.234ms archetype=0.987ms`
+private func compareBackends(scenarioLabel: String, run: (Backend) -> Double) {
+    var results = [String]()
+    for backend in Backend.allCases {
+        let median = measureMedian(label: "\(scenarioLabel) \(backend)") {
+            run(backend)
+        }
+        results.append("\(backend)=\(formatMilliseconds(median))ms")
+    }
+    print("\(scenarioLabel) \(results.joined(separator: " "))")
+}
+
+// MARK: - バックエンド切り替えヘルパ
+
+/// 新旧ストレージを切り替えて World を構築するベンチマーク用ヘルパです。
+///
+/// `Tests/ecs-swiftTests/Archetype/WorldBackend.swift` の最小版の複製です
+/// (testTarget 間は import できないため、Benchmarks ターゲットに重複定義しています)。
+private enum Backend: CaseIterable, CustomStringConvertible {
+    /// 現行実装(chunk ベース)。`World()` と同じです。
+    case legacy
+    /// 新実装(`ExperimentalWorldOptions.archetypeStorage` ON)。
+    case archetype
+
+    /// このバックエンドの World を構築します。
+    func makeWorld() -> World {
+        switch self {
+        case .legacy:
+            return World()
+        case .archetype:
+            return World(experimentalOptions: [.archetypeStorage])
+        }
+    }
+
+    /// 出力で判別しやすくするための表示名です。
+    var description: String {
+        switch self {
+        case .legacy:
+            return "legacy"
+        case .archetype:
+            return "archetype"
+        }
+    }
+}
+
+// MARK: - ベンチマーク用 component
+
+/// シナリオ1(イテレーション)用の 3 型です。
+private struct Position: Component {
+    var x: Double
+    var y: Double
+}
+
+private struct Velocity: Component {
+    var dx: Double
+    var dy: Double
+}
+
+private struct Health: Component {
+    var value: Int
+}
+
+/// シナリオ2・3 で spawn する entity が持つ component です。
+private struct Payload: Component {
+    var value: Int
+}
+
+// MARK: - シナリオ2用マーカー component(k 個の相異なる Query 型)
+
+/// 登録 Query 数 k = 1, 10, 50 を作るためのマーカー component 群です。
+///
+/// `Query<C>` は component 型ごとに別の Query 型になるため、k 個の相異なる Query を
+/// 登録するには k 個の相異なる型が必要です。ジェネリクスやマクロで 50 型を量産する
+/// 仕組みは持たないため、Spike の割り切りとして 50 個をリテラル定義します。
+private enum Markers {
+    struct M1: Component {}
+    struct M2: Component {}
+    struct M3: Component {}
+    struct M4: Component {}
+    struct M5: Component {}
+    struct M6: Component {}
+    struct M7: Component {}
+    struct M8: Component {}
+    struct M9: Component {}
+    struct M10: Component {}
+    struct M11: Component {}
+    struct M12: Component {}
+    struct M13: Component {}
+    struct M14: Component {}
+    struct M15: Component {}
+    struct M16: Component {}
+    struct M17: Component {}
+    struct M18: Component {}
+    struct M19: Component {}
+    struct M20: Component {}
+    struct M21: Component {}
+    struct M22: Component {}
+    struct M23: Component {}
+    struct M24: Component {}
+    struct M25: Component {}
+    struct M26: Component {}
+    struct M27: Component {}
+    struct M28: Component {}
+    struct M29: Component {}
+    struct M30: Component {}
+    struct M31: Component {}
+    struct M32: Component {}
+    struct M33: Component {}
+    struct M34: Component {}
+    struct M35: Component {}
+    struct M36: Component {}
+    struct M37: Component {}
+    struct M38: Component {}
+    struct M39: Component {}
+    struct M40: Component {}
+    struct M41: Component {}
+    struct M42: Component {}
+    struct M43: Component {}
+    struct M44: Component {}
+    struct M45: Component {}
+    struct M46: Component {}
+    struct M47: Component {}
+    struct M48: Component {}
+    struct M49: Component {}
+    struct M50: Component {}
+}
+
+/// マーカー Query を 1 つ登録する処理の一覧です(先頭 k 個を使用します)。
+///
+/// system parameter として `Query<Mi>` を持つ空 system を追加することで、
+/// `addSystem` 時の `register(to:)` により Query が World に登録されます。
+private let markerQueryRegistrations: [(World) -> Void] = [
+    { $0.addSystem(.update) { (_: Query<Markers.M1>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M2>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M3>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M4>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M5>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M6>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M7>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M8>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M9>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M10>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M11>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M12>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M13>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M14>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M15>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M16>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M17>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M18>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M19>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M20>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M21>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M22>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M23>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M24>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M25>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M26>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M27>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M28>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M29>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M30>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M31>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M32>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M33>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M34>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M35>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M36>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M37>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M38>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M39>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M40>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M41>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M42>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M43>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M44>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M45>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M46>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M47>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M48>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M49>) in } },
+    { $0.addSystem(.update) { (_: Query<Markers.M50>) in } },
+]
+
+// MARK: - ベンチマーク本体
+
+/// 新旧バックエンド比較ベンチマークです(タスク 8.1, 8.2 / 要件 5-1〜5-5, 3-4)。
+///
+/// ## 実行方法
+///
+/// CI では各テスト冒頭の環境変数ゲートにより skip され(即 return して pass)、
+/// 手動実行時のみ以下で計測します(design.md「CI には含めない」の運用):
+///
+/// ```sh
+/// RUN_BENCHMARKS=1 swift test -c release --filter Benchmarks
+/// ```
+///
+/// ## 計測方式
+///
+/// - `ContinuousClock` による手動計測(セットアップは計測区間外)
+/// - 各計測点は `benchmarkRuns` 回実行の中央値(tasks.md 8.3)
+/// - 新旧を同一シナリオ・同一 entity 数(10^3 / 10^4 / 10^5)で比較し、
+///   `scenarioX ... legacy=...ms archetype=...ms` 形式で出力します
+struct ArchetypeBenchmarks {
+
+    // MARK: シナリオ1: イテレーション (要件 5-2, 5-3)
+
+    /// 3 型 component × N entities を `Query3` で全更新する update ループ
+    /// (100 フレーム)を計測します。
+    ///
+    /// 計測対象は `world.update(currentTime:)` × 100 フレームのループ全体で、
+    /// spawn の flush(準備フレーム)は計測区間外です。フレーム数は N によらず
+    /// 100 で固定し、新旧で完全に対称な条件とします。
+    @Test func scenario1Iteration() {
+        guard benchmarksEnabled else { return }
+        let frames = 100
+        for entityCount in entityCounts {
+            compareBackends(
+                scenarioLabel: "scenario1 iteration N=\(entityCount) frames=\(frames)"
+            ) { backend in
+                self.iterationRun(backend: backend, entityCount: entityCount, frames: frames)
+            }
+        }
+    }
+
+    private func iterationRun(backend: Backend, entityCount: Int, frames: Int) -> Double {
+        let world = backend.makeWorld()
+        world.addSystem(.update) { (query: Query3<Position, Velocity, Health>) in
+            query.update { position, velocity, health in
+                position.x += velocity.dx
+                position.y += velocity.dy
+                health.value &+= 1
+            }
+        }
+
+        let commands = world.worldStorage.commands
+        for _ in 0..<entityCount {
+            commands.spawn()
+                .addComponent(Position(x: 0, y: 0))
+                .addComponent(Velocity(dx: 1, dy: 1))
+                .addComponent(Health(value: 0))
+        }
+
+        // 準備フレーム: system は実行されず、spawn の flush のみ行われます(計測区間外)。
+        world.update(currentTime: 0)
+
+        // 計測対象: 100 フレームの update ループ。
+        return measureMilliseconds {
+            for frame in 1...frames {
+                world.update(currentTime: TimeInterval(frame))
+            }
+        }
+    }
+
+    // MARK: シナリオ2: spawn/despawn (要件 5-1, 5-4)
+
+    /// 登録 Query 数 k = 1, 10, 50 の World で N entities を spawn → 全 despawn する
+    /// コストを計測します(要件 5-1「Query 数非比例」を k の変化で観測)。
+    ///
+    /// - マーカー Query は spawn する entity(`Payload` のみ)とマッチしません。
+    ///   legacy では spawn/despawn が全 chunk へ broadcast されるため、マッチしない
+    ///   Query の数に比例する分のコストがそのまま観測できます。
+    /// - 計測対象: N spawn の enqueue + flush フレーム 1 回、全 despawn の
+    ///   enqueue + flush フレーム 1 回(それぞれ 1 フレームずつ)。
+    @Test func scenario2SpawnDespawn() {
+        guard benchmarksEnabled else { return }
+        for entityCount in entityCounts {
+            for queryCount in [1, 10, 50] {
+                compareBackends(
+                    scenarioLabel: "scenario2 spawnDespawn N=\(entityCount) k=\(queryCount)"
+                ) { backend in
+                    self.spawnDespawnRun(
+                        backend: backend,
+                        entityCount: entityCount,
+                        queryCount: queryCount
+                    )
+                }
+            }
+        }
+    }
+
+    private func spawnDespawnRun(backend: Backend, entityCount: Int, queryCount: Int) -> Double {
+        precondition(
+            queryCount <= markerQueryRegistrations.count,
+            "queryCount exceeds the number of marker components."
+        )
+        let world = backend.makeWorld()
+        for register in markerQueryRegistrations.prefix(queryCount) {
+            register(world)
+        }
+        let commands = world.worldStorage.commands
+
+        // 準備フレーム(計測区間外)。
+        world.update(currentTime: 0)
+
+        return measureMilliseconds {
+            var entities = [Entity]()
+            entities.reserveCapacity(entityCount)
+            for _ in 0..<entityCount {
+                let entity = commands.spawn()
+                    .addComponent(Payload(value: 0))
+                    .id()
+                entities.append(entity)
+            }
+            // spawn の flush フレーム。
+            world.update(currentTime: 1)
+
+            for entity in entities {
+                commands.despawn(entity: entity)
+            }
+            // despawn の flush フレーム。
+            world.update(currentTime: 2)
+        }
+    }
+
+    // MARK: シナリオ3: 空コマンド (要件 3-4 の退行検出)
+
+    /// N の生存 entity へ `commands.entity(e)` のみ(component 変更なし)を発行し、
+    /// enqueue + flush フレーム 1 回を計測します。
+    ///
+    /// - archetype ON では空 diff は no-op マーカーとして早期に捨てられるはずで
+    ///   (要件 3-4)、その退行を検出します。
+    /// - legacy 側で updated-entity queue の適用先となる chunk が存在するよう、
+    ///   `Query<Payload>` を 1 つ登録した状態で比較します(新旧同条件)。
+    @Test func scenario3EmptyCommands() {
+        guard benchmarksEnabled else { return }
+        for entityCount in entityCounts {
+            compareBackends(
+                scenarioLabel: "scenario3 emptyCommands N=\(entityCount)"
+            ) { backend in
+                self.emptyCommandsRun(backend: backend, entityCount: entityCount)
+            }
+        }
+    }
+
+    private func emptyCommandsRun(backend: Backend, entityCount: Int) -> Double {
+        let world = backend.makeWorld()
+        world.addSystem(.update) { (_: Query<Payload>) in }
+        let commands = world.worldStorage.commands
+
+        var entities = [Entity]()
+        entities.reserveCapacity(entityCount)
+        for _ in 0..<entityCount {
+            let entity = commands.spawn()
+                .addComponent(Payload(value: 0))
+                .id()
+            entities.append(entity)
+        }
+
+        // 準備フレーム: spawn の flush(計測区間外)。
+        world.update(currentTime: 0)
+
+        return measureMilliseconds {
+            for entity in entities {
+                _ = commands.entity(entity)
+            }
+            // 空コマンドの flush フレーム。
+            world.update(currentTime: 1)
+        }
+    }
+}

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeCommandsPhaseTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeCommandsPhaseTests.swift
@@ -1,0 +1,182 @@
+//
+//  ArchetypeCommandsPhaseTests.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+@testable import ECS
+import Testing
+
+/// World 分岐点 4 (`applyCommandsPhase`) の archetype storage ON 経路のテストです。
+///
+/// `world.update(currentTime:)` の 1 フレームを実際に回し、`Commands` 経由の
+/// spawn / despawn がフレームの適用フェーズで Archetype ストレージへ反映されることを
+/// 検証します(要件 1-1, 1-5, 3-1)。diff queue の適用はタスク 6.3 で結線されるため、
+/// ここでは扱いません。
+struct ArchetypeCommandsPhaseTests {
+
+    struct ComponentA: Component, Equatable {
+        let value: Int
+    }
+
+    struct ComponentB: Component, Equatable {
+        let text: String
+    }
+
+    private func column<T: Component>(
+        of type: T.Type,
+        in archetype: Archetype,
+        storage: ArchetypeStorageRef
+    ) throws -> Column<T> {
+        let id = storage.typeID(for: ObjectIdentifier(T.self))
+        return try #require(archetype.column(of: id) as? Column<T>)
+    }
+
+    // MARK: - spawn の適用 (要件 1-1, 3-1)
+
+    /// ON: `commands.spawn().addComponent(...)` がフレームの適用フェーズ後に
+    /// Archetype へ挿入され、両コンポーネントの値が正しいことを確認します。
+    /// spawn API は現行と同一です(要件 3-1)。
+    @Test func spawnCommandInsertsEntityIntoArchetypeAfterApply() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .addComponent(ComponentB(text: "x"))
+            .id()
+
+        world.update(currentTime: 0)
+
+        // 適用後は entityIndex から所在を引けます。
+        let location = try #require(storage.location(of: entity))
+        #expect(location.archetype.entities[location.row] == entity)
+
+        // spawn コマンドで追加した両コンポーネントの値が挿入されています。
+        let columnA = try self.column(of: ComponentA.self, in: location.archetype, storage: storage)
+        let columnB = try self.column(of: ComponentB.self, in: location.archetype, storage: storage)
+        #expect(columnA.data[location.row] == ComponentA(value: 1))
+        #expect(columnB.data[location.row] == ComponentB(text: "x"))
+
+        // staging queue は適用後にクリアされます。
+        #expect(storage.spawnStagingQueue.isEmpty)
+    }
+
+    // MARK: - 遅延適用 (要件 1-5)
+
+    /// ON: フレーム N 中に spawn した entity は、同フレームの後続システムからは
+    /// まだストレージ上に見えず(遅延適用)、フレームの適用フェーズ後に見えるように
+    /// なることを確認します(Query は ON では未結線のため、ストレージ直接参照で
+    /// 検証します)。
+    @Test func spawnIsNotVisibleInStorageUntilApplyPhase() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+
+        var spawnedEntity: Entity?
+        var locationVisibleMidFrame: Bool?
+        var stagingCountMidFrame: Int?
+
+        world
+            .addSystem(.update) { (commands: Commands) in
+                guard spawnedEntity == nil else { return }
+                spawnedEntity = commands.spawn()
+                    .addComponent(ComponentA(value: 7))
+                    .id()
+            }
+            .addSystem(.update) { (_: Commands) in
+                guard let entity = spawnedEntity, locationVisibleMidFrame == nil else { return }
+                locationVisibleMidFrame = storage.location(of: entity) != nil
+                stagingCountMidFrame = storage.spawnStagingQueue.count
+            }
+
+        // 最初のフレームは準備用フレームのため, システムは 2 フレーム目から実行されます.
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        let entity = try #require(spawnedEntity)
+
+        // 同フレーム内の後続システムからはまだストレージに反映されていません。
+        #expect(locationVisibleMidFrame == false)
+        #expect(stagingCountMidFrame == 0)
+
+        // フレームの適用フェーズ後は所在を引けます。
+        let location = try #require(storage.location(of: entity))
+        let columnA = try self.column(of: ComponentA.self, in: location.archetype, storage: storage)
+        #expect(columnA.data[location.row] == ComponentA(value: 7))
+    }
+
+    // MARK: - despawn の適用 (要件 1-2, 1-5)
+
+    /// ON: 後続フレームでの `commands.despawn(_)` が適用フェーズ後にストレージから
+    /// entity を削除することを確認します。
+    @Test func despawnCommandRemovesEntityFromStorageAfterApply() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+        let archetype = try #require(storage.location(of: entity)).archetype
+
+        commands.despawn(entity: entity)
+        world.update(currentTime: 1)
+
+        // 所在・entity table・Archetype の行がすべて削除されています。
+        #expect(storage.location(of: entity) == nil)
+        #expect(world.entityRecord(forEntity: entity) == nil)
+        #expect(archetype.entities.isEmpty)
+        let columnA = try self.column(of: ComponentA.self, in: archetype, storage: storage)
+        #expect(columnA.data.isEmpty)
+    }
+
+    // MARK: - Spawned イベント (要件 1-6)
+
+    /// ON: spawn した entity の `Spawned` イベントが次フレームの `EventReader` システムに
+    /// 配信されることを確認します(OFF 経路の既存セマンティクスと同一)。
+    @Test func spawnedEventIsDeliveredToReaderSystemOnNextFrame() throws {
+        var spawnedEntity: Entity?
+        var received = [Entity]()
+
+        let world = World(experimentalOptions: [.archetypeStorage])
+            .addSystem(.startUp) { (commands: Commands) in
+                spawnedEntity = commands.spawn()
+                    .addComponent(ComponentA(value: 1))
+                    .id()
+            }
+            .addSystem(.update) { (events: EventReader<Spawned>) in
+                events.forEach { received.append($0.spawnedEntity) }
+            }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        let entity = try #require(spawnedEntity)
+        #expect(received == [entity])
+    }
+
+    // MARK: - OFF 経路の維持 (要件 4-1)
+
+    /// OFF: 従来の spawn / despawn フローが影響を受けないことを確認します
+    /// (完全な保証は既存テストスイート全体の通過によります)。
+    @Test func offWorldSpawnAndDespawnKeepCurrentBehavior() throws {
+        let world = World()
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+
+        let record = try #require(world.entityRecord(forEntity: entity))
+        #expect(record.ref(ComponentA.self)?.value == ComponentA(value: 1))
+
+        commands.despawn(entity: entity)
+        world.update(currentTime: 1)
+
+        #expect(world.entityRecord(forEntity: entity) == nil)
+    }
+}

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeCommandsPhaseTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeCommandsPhaseTests.swift
@@ -48,6 +48,7 @@ struct ArchetypeCommandsPhaseTests {
             .addComponent(ComponentB(text: "x"))
             .id()
 
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         // 適用後は entityIndex から所在を引けます。
@@ -92,6 +93,7 @@ struct ArchetypeCommandsPhaseTests {
             }
 
         // 最初のフレームは準備用フレームのため, システムは 2 フレーム目から実行されます.
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -119,6 +121,7 @@ struct ArchetypeCommandsPhaseTests {
         let entity = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
         let archetype = try #require(storage.location(of: entity)).archetype
 
@@ -151,6 +154,7 @@ struct ArchetypeCommandsPhaseTests {
                 events.forEach { received.append($0.spawnedEntity) }
             }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -169,6 +173,7 @@ struct ArchetypeCommandsPhaseTests {
         let entity = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         let record = try #require(world.entityRecord(forEntity: entity))

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeInsertionTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeInsertionTests.swift
@@ -1,0 +1,140 @@
+//
+//  ArchetypeInsertionTests.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+@testable import ECS
+import Testing
+
+struct ArchetypeInsertionTests {
+
+    struct ComponentA: Component, Equatable {
+        let value: Int
+    }
+
+    struct ComponentB: Component, Equatable {
+        let name: String
+    }
+
+    /// 旧 spawn 経路(Commands.spawn)と同じ手順で staging record を組み立てます.
+    private func makeRecord(entity: Entity) -> EntityRecordRef {
+        let record = EntityRecordRef(entity: entity)
+        record.map.body[ObjectIdentifier(Entity.self)] = ImmutableRef(value: entity)
+        return record
+    }
+
+    // MARK: - insert(record:)
+
+    @Test func insertSingleRecordRegistersLocationAndColumnData() throws {
+        let storage = ArchetypeStorageRef()
+        let entity = Entity(slot: 0, generation: 0)
+        let record = self.makeRecord(entity: entity)
+        record.addComponent(ComponentA(value: 42))
+        record.addComponent(ComponentB(name: "a"))
+
+        storage.insert(record: record)
+
+        let location = try #require(storage.location(of: entity))
+        let archetype = location.archetype
+        #expect(location.row == 0)
+        #expect(archetype.entities == [entity])
+
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let idB = storage.typeID(for: ObjectIdentifier(ComponentB.self))
+        #expect(archetype.key == ArchetypeKey(sorting: [idA, idB]))
+
+        let columnA = try #require(archetype.column(of: idA) as? Column<ComponentA>)
+        let columnB = try #require(archetype.column(of: idB) as? Column<ComponentB>)
+        #expect(columnA.data == [ComponentA(value: 42)])
+        #expect(columnB.data == [ComponentB(name: "a")])
+    }
+
+    @Test func insertTwoRecordsWithDifferentComponentOrderShareArchetype() throws {
+        let storage = ArchetypeStorageRef()
+        let entity0 = Entity(slot: 0, generation: 0)
+        let entity1 = Entity(slot: 1, generation: 0)
+
+        // 同じ型集合を, addComponent の順序を変えて登録します.
+        let record0 = self.makeRecord(entity: entity0)
+        record0.addComponent(ComponentA(value: 1))
+        record0.addComponent(ComponentB(name: "first"))
+        let record1 = self.makeRecord(entity: entity1)
+        record1.addComponent(ComponentB(name: "second"))
+        record1.addComponent(ComponentA(value: 2))
+
+        storage.insert(record: record0)
+        storage.insert(record: record1)
+
+        let location0 = try #require(storage.location(of: entity0))
+        let location1 = try #require(storage.location(of: entity1))
+
+        // 挿入順序が異なっても同一の Archetype インスタンスに合流します.
+        #expect(location0.archetype === location1.archetype)
+        #expect(storage.archetypes.count == 1)
+
+        let archetype = location0.archetype
+        #expect(archetype.entities.count == 2)
+        #expect(location0.row == 0)
+        #expect(location1.row == 1)
+
+        // 各型のカラムに, 行番号どおりの値が格納されています.
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let idB = storage.typeID(for: ObjectIdentifier(ComponentB.self))
+        let columnA = try #require(archetype.column(of: idA) as? Column<ComponentA>)
+        let columnB = try #require(archetype.column(of: idB) as? Column<ComponentB>)
+        #expect(columnA.data == [ComponentA(value: 1), ComponentA(value: 2)])
+        #expect(columnB.data == [ComponentB(name: "first"), ComponentB(name: "second")])
+    }
+
+    @Test func insertRecordWithNoComponentsCreatesEmptyKeyArchetype() throws {
+        let storage = ArchetypeStorageRef()
+        let entity = Entity(slot: 0, generation: 0)
+        let record = self.makeRecord(entity: entity)
+
+        storage.insert(record: record)
+
+        let location = try #require(storage.location(of: entity))
+        // コンポーネント 0 個の entity は空キーの Archetype に所属します.
+        #expect(location.archetype.key == ArchetypeKey(sorting: []))
+        #expect(location.archetype.columns.isEmpty)
+        #expect(location.archetype.entities == [entity])
+        #expect(location.row == 0)
+    }
+
+    // MARK: - applySpawnStaging
+
+    @Test func applySpawnStagingDrainsQueueAndInsertsAllRecords() throws {
+        let storage = ArchetypeStorageRef()
+        let entity0 = Entity(slot: 0, generation: 0)
+        let entity1 = Entity(slot: 1, generation: 0)
+        let record0 = self.makeRecord(entity: entity0)
+        record0.addComponent(ComponentA(value: 10))
+        let record1 = self.makeRecord(entity: entity1)
+        record1.addComponent(ComponentA(value: 20))
+
+        storage.spawnStagingQueue.append(record0)
+        storage.spawnStagingQueue.append(record1)
+
+        storage.applySpawnStaging()
+
+        #expect(storage.spawnStagingQueue.isEmpty)
+        let location0 = try #require(storage.location(of: entity0))
+        let location1 = try #require(storage.location(of: entity1))
+        #expect(location0.archetype === location1.archetype)
+
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let columnA = try #require(location0.archetype.column(of: idA) as? Column<ComponentA>)
+        #expect(columnA.data == [ComponentA(value: 10), ComponentA(value: 20)])
+    }
+
+    @Test func applySpawnStagingWithEmptyQueueDoesNothing() {
+        let storage = ArchetypeStorageRef()
+
+        storage.applySpawnStaging()
+
+        #expect(storage.spawnStagingQueue.isEmpty)
+        #expect(storage.archetypes.isEmpty)
+    }
+}

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeLifecycleTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeLifecycleTests.swift
@@ -1,0 +1,266 @@
+//
+//  ArchetypeLifecycleTests.swift
+//
+//
+//  Created by rrbox on 2026/07/09.
+//
+
+@testable import ECS
+import Testing
+
+/// entity のライフサイクル(spawn / despawn / 構成変更 / slot 再利用 / イベント)を
+/// 新旧両バックエンドで検証する統合テストです(タスク 7.1)。
+///
+/// 全テストは `@Test(arguments: WorldBackend.allCases)` により legacy / archetype の
+/// 両方の World で実行され、公開 API レベルで同一の挙動になることを確認します
+/// (要件 1-1, 1-2, 1-3, 1-4, 1-6, 1-7)。
+struct ArchetypeLifecycleTests {
+
+    struct ComponentA: Component, Equatable {
+        var value: Int
+    }
+
+    struct ComponentB: Component, Equatable {
+        var text: String
+    }
+
+    // MARK: - spawn の反映 (要件 1-1)
+
+    /// spawn したフレームの適用フェーズが完了した後、entity が(指定型以外の
+    /// コンポーネントを追加で持っていても)一致する Query の対象に含まれます。
+    /// spawn 発行フレーム内では未反映(遅延適用)であることも確認します。
+    @Test(arguments: WorldBackend.allCases)
+    func spawnedEntityEntersMatchingQueriesAfterApply(backend: WorldBackend) {
+        let world = backend.makeWorld()
+
+        var spawned = false
+        var perFrame = [[Int]]()
+        world
+            .addSystem(.update) { (commands: Commands) in
+                guard !spawned else { return }
+                spawned = true
+                commands.spawn()
+                    .addComponent(ComponentA(value: 1))
+                commands.spawn()
+                    .addComponent(ComponentA(value: 2))
+                    .addComponent(ComponentB(text: "extra"))
+            }
+            .addSystem(.update) { (query: Query<ComponentA>) in
+                var values = [Int]()
+                query.update { component in
+                    values.append(component.value)
+                }
+                perFrame.append(values.sorted())
+            }
+
+        // 最初のフレームは準備用フレームのため, .update システムは 2 フレーム目から実行されます.
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        // spawn 発行フレームでは空、適用後の次フレームで両 entity が対象に入ります。
+        #expect(perFrame == [[], [1, 2]])
+    }
+
+    // MARK: - despawn の除外 (要件 1-2)
+
+    /// despawn したフレームの適用フェーズが完了した後、entity が Query の
+    /// イテレーションと `components(forEntity:)` の両方から除外されます。
+    @Test(arguments: WorldBackend.allCases)
+    func despawnedEntityIsExcludedFromQueries(backend: WorldBackend) throws {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        let keep = commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .id()
+
+        var perFrame = [[Int]]()
+        world.addSystem(.update) { (query: Query<ComponentA>) in
+            var values = [Int]()
+            query.update { component in
+                values.append(component.value)
+            }
+            perFrame.append(values.sorted())
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        commands.despawn(entity: entity)
+        world.update(currentTime: 2)
+
+        #expect(perFrame == [[1, 2], [2]])
+
+        let query = try #require(Query<ComponentA>.getParameter(from: world.worldStorage))
+        #expect(query.components(forEntity: entity) == nil)
+        #expect(query.components(forEntity: keep) == ComponentA(value: 2))
+    }
+
+    // MARK: - 構成変更による Query 対象の出入り (要件 1-3)
+
+    /// 既存 entity への `addComponent` の適用完了後、変更後の型集合に一致する
+    /// Query の対象に entity が入ります。
+    @Test(arguments: WorldBackend.allCases)
+    func addComponentMovesEntityIntoQueryScope(backend: WorldBackend) {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+
+        var perFrame = [[Int]]()
+        world.addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+            var values = [Int]()
+            query.update { a, _ in
+                values.append(a.value)
+            }
+            perFrame.append(values)
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        commands.entity(entity).addComponent(ComponentB(text: "b"))
+        world.update(currentTime: 2)
+
+        // B 追加前は対象外、追加の適用後に対象へ入ります。
+        #expect(perFrame == [[], [1]])
+    }
+
+    /// 既存 entity からの `removeComponent` の適用完了後、削除した型を要求する
+    /// Query の対象から entity が外れます(残った型の Query には残ります)。
+    @Test(arguments: WorldBackend.allCases)
+    func removeComponentMovesEntityOutOfQueryScope(backend: WorldBackend) throws {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 7))
+            .addComponent(ComponentB(text: "x"))
+            .id()
+
+        var perFrame = [[Int]]()
+        world
+            .addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+                var values = [Int]()
+                query.update { a, _ in
+                    values.append(a.value)
+                }
+                perFrame.append(values)
+            }
+            // 残存側の確認用に Query<ComponentA> を register しておきます。
+            .addSystem(.update) { (_: Query<ComponentA>) in }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        commands.entity(entity).removeComponent(ofType: ComponentB.self)
+        world.update(currentTime: 2)
+
+        #expect(perFrame == [[7], []])
+
+        // 残った A のみを要求する Query には引き続き含まれます。
+        let queryA = try #require(Query<ComponentA>.getParameter(from: world.worldStorage))
+        #expect(queryA.components(forEntity: entity) == ComponentA(value: 7))
+    }
+
+    // MARK: - slot 再利用の世代分離 (要件 1-4)
+
+    /// despawn された slot が新しい世代で再利用された場合、古い世代の entity としての
+    /// アクセス(`components(forEntity:)` / `update(_:_:)`)はデータを返しません。
+    @Test(arguments: WorldBackend.allCases)
+    func slotReuseDoesNotExposeDataToOldGeneration(backend: WorldBackend) throws {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        // Query を register するためのシステムです(内容は使いません)。
+        world.addSystem(.update) { (_: Query<ComponentA>) in }
+
+        let old = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+
+        commands.despawn(entity: old)
+        world.update(currentTime: 1)
+
+        // despawn で stack された slot が新しい世代で再利用されます(EntityGenerator の規約)。
+        let reused = commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .id()
+        #expect(reused.slot == old.slot)
+        #expect(reused.generation == old.generation + 1)
+
+        world.update(currentTime: 2)
+
+        let query = try #require(Query<ComponentA>.getParameter(from: world.worldStorage))
+        #expect(query.components(forEntity: reused) == ComponentA(value: 2))
+
+        // 古い世代としてのアクセスは読み取り・書き込みともに何も起こしません。
+        #expect(query.components(forEntity: old) == nil)
+        var oldGenerationTouched = false
+        query.update(old) { _ in
+            oldGenerationTouched = true
+        }
+        #expect(!oldGenerationTouched)
+        #expect(query.components(forEntity: reused) == ComponentA(value: 2))
+    }
+
+    // MARK: - Spawned イベント (要件 1-6)
+
+    /// spawn の適用時に `Spawned` イベントが発行され、次フレームの
+    /// `EventReader<Spawned>` システムに配信されます。
+    @Test(arguments: WorldBackend.allCases)
+    func spawnApplyEmitsSpawnedEvent(backend: WorldBackend) {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        var received = [Entity]()
+        world.addSystem(.update) { (events: EventReader<Spawned>) in
+            events.forEach { event in
+                received.append(event.spawnedEntity)
+            }
+        }
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        #expect(received == [entity])
+    }
+
+    // MARK: - Removed スケジュール (要件 1-7)
+
+    /// despawn の適用時に `.removed` スケジュールのシステムが実行され、
+    /// 削除された entity 一覧が渡されます。
+    @Test(arguments: WorldBackend.allCases)
+    func despawnApplyRunsRemovedScheduleWithEntities(backend: WorldBackend) {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        var received = [Entity]()
+        world.addSystem(.removed) { (removed: Removed) in
+            removed.forEach { removedEntity in
+                received.append(removedEntity)
+            }
+        }
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+
+        commands.despawn(entity: entity)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        #expect(received == [entity])
+    }
+}

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeLifecycleTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeLifecycleTests.swift
@@ -54,6 +54,7 @@ struct ArchetypeLifecycleTests {
             }
 
         // 最初のフレームは準備用フレームのため, .update システムは 2 フレーム目から実行されます.
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)
@@ -87,6 +88,7 @@ struct ArchetypeLifecycleTests {
             perFrame.append(values.sorted())
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -122,6 +124,7 @@ struct ArchetypeLifecycleTests {
             perFrame.append(values)
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -156,6 +159,7 @@ struct ArchetypeLifecycleTests {
             // 残存側の確認用に Query<ComponentA> を register しておきます。
             .addSystem(.update) { (_: Query<ComponentA>) in }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -184,6 +188,7 @@ struct ArchetypeLifecycleTests {
         let old = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         commands.despawn(entity: old)
@@ -230,6 +235,7 @@ struct ArchetypeLifecycleTests {
         let entity = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -255,6 +261,7 @@ struct ArchetypeLifecycleTests {
         let entity = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         commands.despawn(entity: entity)

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeQueryNTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeQueryNTests.swift
@@ -1,0 +1,352 @@
+//
+//  ArchetypeQueryNTests.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+@testable import ECS
+import Testing
+
+/// `QueryN`(マクロ生成、2〜10型)デュアルバックエンドの archetype storage ON 経路の
+/// テストです(タスク 5.3)。
+///
+/// `world.update(currentTime:)` のフレームを実際に回し、system parameter として
+/// 解決された `QueryN` が Archetype バックエンドで動作することを検証します
+/// (要件 2-1〜2-4, 2-6, 2-7)。公開 API(`update` / `components(forEntity:)`)は
+/// OFF 経路と同一です。
+struct ArchetypeQueryNTests {
+
+    struct ComponentA: Component, Equatable {
+        var value: Int
+    }
+
+    struct ComponentB: Component, Equatable {
+        var text: String
+    }
+
+    // MARK: - 部分集合マッチ (要件 2-1, 2-2)
+
+    /// ON: `Query2<A, B>` が「A と B の両方を持つ」entity のみをイテレーションし、
+    /// 値が正しく渡されることを確認します(A のみ・B のみの entity は除外されます)。
+    @Test func query2IteratesOnlyEntitiesWithBothComponents() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.spawn()
+            .addComponent(ComponentA(value: 1))
+        commands.spawn()
+            .addComponent(ComponentB(text: "onlyB"))
+        commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .addComponent(ComponentB(text: "both"))
+
+        var observed = [(Int, String)]()
+        world.addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+            guard observed.isEmpty else { return }
+            query.update { a, b in
+                observed.append((a.value, b.text))
+            }
+        }
+
+        // 最初のフレームは準備用フレームのため, .update システムは 2 フレーム目から実行されます.
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        #expect(observed.count == 1)
+        #expect(observed.first?.0 == 2)
+        #expect(observed.first?.1 == "both")
+    }
+
+    // MARK: - 変更の永続化 (要件 2-4)
+
+    /// ON: `update(_:)` での変更が次フレームまで永続化されることを確認します。
+    @Test func query2MutationPersistsAcrossFrames() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.spawn()
+            .addComponent(ComponentA(value: 0))
+            .addComponent(ComponentB(text: ""))
+
+        var readBack = [[Int]]()
+        world.addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+            var values = [Int]()
+            query.update { a, b in
+                values.append(a.value)
+                a.value += 1
+                b.text += "x"
+            }
+            readBack.append(values)
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        // フレーム 1 で 0 を読み +1、フレーム 2 で永続化された 1 を読みます。
+        #expect(readBack == [[0], [1]])
+    }
+
+    // MARK: - 型順非依存 (要件 2-3)
+
+    /// ON: `Query2<A, B>` と `Query2<B, A>` が同一フレームで同じ entity 集合を
+    /// 観測することを確認します。
+    @Test func query2TypeOrderDoesNotAffectMatchedEntitySet() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .addComponent(ComponentB(text: "p"))
+        commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .addComponent(ComponentB(text: "q"))
+        commands.spawn()
+            .addComponent(ComponentA(value: 3))
+
+        var observedAB = Set<Int>()
+        var observedBA = Set<Int>()
+        world
+            .addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+                query.update { a, _ in
+                    observedAB.insert(a.value)
+                }
+            }
+            .addSystem(.update) { (query: Query2<ComponentB, ComponentA>) in
+                query.update { _, a in
+                    observedBA.insert(a.value)
+                }
+            }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        #expect(observedAB == [1, 2])
+        #expect(observedAB == observedBA)
+    }
+
+    // MARK: - Entity ターゲット (要件 2-6)
+
+    /// ON: `Query3<Entity, A, B>` がイテレーションで entity ID を渡すことを確認します。
+    @Test func query3WithEntityTargetPassesEntityIDs() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        let target = commands.spawn()
+            .addComponent(ComponentA(value: 7))
+            .addComponent(ComponentB(text: "e"))
+            .id()
+        commands.spawn()
+            .addComponent(ComponentA(value: 8))
+
+        var observed = [(Entity, Int, String)]()
+        world.addSystem(.update) { (query: Query3<Entity, ComponentA, ComponentB>) in
+            guard observed.isEmpty else { return }
+            query.update { entity, a, b in
+                observed.append((entity, a.value, b.text))
+            }
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        #expect(observed.count == 1)
+        #expect(observed.first?.0 == target)
+        #expect(observed.first?.1 == 7)
+        #expect(observed.first?.2 == "e")
+    }
+
+    /// ON: Entity ターゲットを含む場合でも、column ターゲットへの変更は永続化される
+    /// ことを確認します(Entity への書き込みは破棄されます)。
+    @Test func query3MixedEntityAndColumnMutationPersistsForColumns() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.spawn()
+            .addComponent(ComponentA(value: 0))
+            .addComponent(ComponentB(text: ""))
+
+        var readBack = [[Int]]()
+        world.addSystem(.update) { (query: Query3<Entity, ComponentA, ComponentB>) in
+            var values = [Int]()
+            query.update { _, a, _ in
+                values.append(a.value)
+                a.value += 10
+            }
+            readBack.append(values)
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        #expect(readBack == [[0], [10]])
+    }
+
+    // MARK: - entity 指定アクセス (要件 2-7)
+
+    /// ON: `update(_:_:)` による対象 entity のみの読み書きと、
+    /// `components(forEntity:)` での取得が動作することを確認します。
+    @Test func query2TargetedUpdateAndComponentsForEntity() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        let target = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .addComponent(ComponentB(text: "t"))
+            .id()
+        let other = commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .addComponent(ComponentB(text: "o"))
+            .id()
+
+        var didWrite = false
+        var results: [Int?]?
+        world.addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+            if !didWrite {
+                didWrite = true
+                query.update(target) { a, b in
+                    a.value = 10
+                    b.text = "written"
+                }
+            } else if results == nil {
+                results = [
+                    query.components(forEntity: target)?.0.value,
+                    query.components(forEntity: other)?.0.value,
+                ]
+                #expect(query.components(forEntity: target)?.1.text == "written")
+                #expect(query.components(forEntity: other)?.1.text == "o")
+            }
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        #expect(results == [10, 2])
+    }
+
+    /// ON: `Query2` の対象型を持たない entity への `update(_:_:)` /
+    /// `components(forEntity:)` は no-op / nil であることを確認します。
+    @Test func query2TargetedAccessToNonMatchingEntityIsNoOp() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        let onlyA = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+
+        var called = false
+        var result: (ComponentA, ComponentB)?
+        world.addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+            query.update(onlyA) { _, _ in
+                called = true
+            }
+            result = query.components(forEntity: onlyA)
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        #expect(called == false)
+        #expect(result == nil)
+    }
+
+    // MARK: - despawn の反映 (要件 1-2 の Query ビュー)
+
+    /// ON: despawn された entity が以降の `Query2` のイテレーションと
+    /// `components(forEntity:)` から除外されることを確認します。
+    @Test func query2DespawnedEntityIsNoLongerIterated() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .addComponent(ComponentB(text: "d"))
+            .id()
+
+        var perFrame = [[Int]]()
+        world.addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+            var values = [Int]()
+            query.update { a, _ in
+                values.append(a.value)
+            }
+            perFrame.append(values)
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        commands.despawn(entity: entity)
+        world.update(currentTime: 2)
+
+        #expect(perFrame == [[1], []])
+
+        let query = try #require(
+            Query2<ComponentA, ComponentB>.getParameter(from: world.worldStorage)
+        )
+        #expect(query.components(forEntity: entity) == nil)
+    }
+
+    // MARK: - register 後に生成された Archetype の観測 (observer 経路)
+
+    /// ON: Query2 の register 後、後続フレーム中の spawn で生成された Archetype が
+    /// オブザーバ通知経由でマッチに追加されることを確認します。
+    @Test func query2ObservesArchetypeCreatedAfterRegister() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+
+        var spawned = false
+        var perFrame = [[Int]]()
+        world
+            .addSystem(.update) { (commands: Commands) in
+                guard !spawned else { return }
+                spawned = true
+                commands.spawn()
+                    .addComponent(ComponentA(value: 5))
+                    .addComponent(ComponentB(text: "late"))
+            }
+            .addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+                var values = [Int]()
+                query.update { a, _ in
+                    values.append(a.value)
+                }
+                perFrame.append(values)
+            }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        // フレーム 1 では spawn は遅延適用のため空、フレーム 2 で見えます。
+        #expect(perFrame == [[], [5]])
+    }
+
+    // MARK: - OFF 経路の維持 (要件 4-1)
+
+    /// OFF: 従来の Query2 の挙動(イテレーション・変更の永続化・entity 指定取得)が
+    /// 影響を受けないことを確認します(完全な保証は既存テストスイート全体の通過によります)。
+    @Test func offWorldQuery2KeepsCurrentBehavior() throws {
+        let world = World()
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .addComponent(ComponentB(text: "off"))
+            .id()
+
+        var readBack = [Int?]()
+        world.addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+            readBack.append(query.components(forEntity: entity)?.0.value)
+            query.update { a, _ in
+                a.value += 1
+            }
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        #expect(readBack == [1, 2])
+    }
+}

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeQueryNTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeQueryNTests.swift
@@ -50,6 +50,7 @@ struct ArchetypeQueryNTests {
         }
 
         // 最初のフレームは準備用フレームのため, .update システムは 2 フレーム目から実行されます.
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -80,6 +81,7 @@ struct ArchetypeQueryNTests {
             readBack.append(values)
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)
@@ -119,6 +121,7 @@ struct ArchetypeQueryNTests {
                 }
             }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -148,6 +151,7 @@ struct ArchetypeQueryNTests {
             }
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -177,6 +181,7 @@ struct ArchetypeQueryNTests {
             readBack.append(values)
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)
@@ -220,6 +225,7 @@ struct ArchetypeQueryNTests {
             }
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)
@@ -246,6 +252,7 @@ struct ArchetypeQueryNTests {
             result = query.components(forEntity: onlyA)
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -275,6 +282,7 @@ struct ArchetypeQueryNTests {
             perFrame.append(values)
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -314,6 +322,7 @@ struct ArchetypeQueryNTests {
                 perFrame.append(values)
             }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)
@@ -343,6 +352,7 @@ struct ArchetypeQueryNTests {
             }
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeQueryTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeQueryTests.swift
@@ -47,6 +47,7 @@ struct ArchetypeQueryTests {
         }
 
         // 最初のフレームは準備用フレームのため, .update システムは 2 フレーム目から実行されます.
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -73,6 +74,7 @@ struct ArchetypeQueryTests {
             }
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)
@@ -104,6 +106,7 @@ struct ArchetypeQueryTests {
             }
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -141,6 +144,7 @@ struct ArchetypeQueryTests {
             }
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)
@@ -172,6 +176,7 @@ struct ArchetypeQueryTests {
                 perFrame.append(values)
             }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)
@@ -193,6 +198,7 @@ struct ArchetypeQueryTests {
             .addComponent(ComponentA(value: 3))
 
         // Query 未登録のままフレームを回し、Archetype を先に生成します。
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         var observed = [Int]()
@@ -233,6 +239,7 @@ struct ArchetypeQueryTests {
             perFrame.append(values)
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -265,6 +272,7 @@ struct ArchetypeQueryTests {
             }
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
         world.update(currentTime: 2)
@@ -305,6 +313,7 @@ struct ArchetypeQueryTests {
                 }
             }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -342,6 +351,7 @@ struct ArchetypeQueryTests {
                 }
             }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -374,6 +384,7 @@ struct ArchetypeQueryTests {
                 }
             }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -405,6 +416,7 @@ struct ArchetypeQueryTests {
 
         // Query を register するためのシステムです(内容は使いません)。
         world.addSystem(.update) { (_: Query<ComponentA>) in }
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         let query = try #require(Query<ComponentA>.getParameter(from: world.worldStorage))

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeQueryTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeQueryTests.swift
@@ -1,0 +1,274 @@
+//
+//  ArchetypeQueryTests.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+@testable import ECS
+import Testing
+
+/// `Query<C>`(1型)デュアルバックエンドの archetype storage ON 経路のテストです(タスク 5.2)。
+///
+/// `world.update(currentTime:)` のフレームを実際に回し、system parameter として
+/// 解決された `Query<C>` が Archetype バックエンドで動作することを検証します
+/// (要件 2-1, 2-2, 2-4, 2-6, 2-7)。公開 API(`update` / `components(forEntity:)`)は
+/// OFF 経路と同一です。
+struct ArchetypeQueryTests {
+
+    struct ComponentA: Component, Equatable {
+        var value: Int
+    }
+
+    struct ComponentB: Component, Equatable {
+        var text: String
+    }
+
+    // MARK: - 部分集合マッチ (要件 2-1, 2-2)
+
+    /// ON: `Query<ComponentA>` が「A のみ」「A + B」両方の entity をイテレーションする
+    /// ことを確認します(要求型集合 ⊆ archetype 型集合の部分集合マッチ)。
+    @Test func queryIteratesEntitiesWithSubsetMatching() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.spawn()
+            .addComponent(ComponentA(value: 1))
+        commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .addComponent(ComponentB(text: "x"))
+
+        var observed = [Int]()
+        world.addSystem(.update) { (query: Query<ComponentA>) in
+            guard observed.isEmpty else { return }
+            query.update { component in
+                observed.append(component.value)
+            }
+        }
+
+        // 最初のフレームは準備用フレームのため, .update システムは 2 フレーム目から実行されます.
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        #expect(observed.sorted() == [1, 2])
+    }
+
+    // MARK: - 変更の永続化 (要件 2-4, 2-7)
+
+    /// ON: `update(_:)` での変更が次フレームまで永続化され、`components(forEntity:)`
+    /// からも見えることを確認します。
+    @Test func mutationPersistsAcrossFramesAndIsVisibleViaComponentsForEntity() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 0))
+            .id()
+
+        var readBack = [Int?]()
+        world.addSystem(.update) { (query: Query<ComponentA>) in
+            readBack.append(query.components(forEntity: entity)?.value)
+            query.update { component in
+                component.value += 1
+            }
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        // フレーム 1 で 0 を読み +1、フレーム 2 で永続化された 1 を読みます。
+        #expect(readBack == [0, 1])
+    }
+
+    // MARK: - Entity ターゲット (要件 2-6)
+
+    /// ON: `Query<Entity>` が(コンポーネントを持たない entity も含め)全 entity の
+    /// ID をイテレーションすることを確認します。
+    @Test func entityTargetQueryIteratesAllEntityIDs() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        let entityA = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        let entityB = commands.spawn()
+            .addComponent(ComponentB(text: "x"))
+            .id()
+        let bareEntity = commands.spawn().id()
+
+        var observed = Set<Entity>()
+        world.addSystem(.update) { (query: Query<Entity>) in
+            query.update { entity in
+                observed.insert(entity)
+            }
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        #expect(observed == [entityA, entityB, bareEntity])
+    }
+
+    // MARK: - entity 指定アクセス (要件 2-7)
+
+    /// ON: `update(_:_:)` による対象 entity のみの読み書きが動作し、他の entity に
+    /// 影響しないことを確認します。
+    @Test func targetedUpdateReadsAndWritesSingleEntity() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        let target = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        let other = commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .id()
+
+        var didWrite = false
+        var results: [Int?]?
+        world.addSystem(.update) { (query: Query<ComponentA>) in
+            if !didWrite {
+                didWrite = true
+                query.update(target) { component in
+                    component.value = 10
+                }
+            } else if results == nil {
+                results = [
+                    query.components(forEntity: target)?.value,
+                    query.components(forEntity: other)?.value,
+                ]
+            }
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        #expect(results == [10, 2])
+    }
+
+    // MARK: - register 後に生成された Archetype の観測 (observer 経路)
+
+    /// ON: Query の register 時点で Archetype が存在せず、後続フレーム中の spawn で
+    /// 生成された Archetype がオブザーバ通知経由でマッチに追加されることを確認します。
+    @Test func archetypeCreatedAfterRegisterIsObserved() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+
+        var spawned = false
+        var perFrame = [[Int]]()
+        world
+            .addSystem(.update) { (commands: Commands) in
+                guard !spawned else { return }
+                spawned = true
+                commands.spawn()
+                    .addComponent(ComponentA(value: 5))
+            }
+            .addSystem(.update) { (query: Query<ComponentA>) in
+                var values = [Int]()
+                query.update { component in
+                    values.append(component.value)
+                }
+                perFrame.append(values)
+            }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        // フレーム 1 では spawn は遅延適用のため空、フレーム 2 で見えます。
+        #expect(perFrame == [[], [5]])
+    }
+
+    // MARK: - 既存 Archetype への遡及マッチ (retro-match 経路)
+
+    /// ON: Query の register より前に生成済みの Archetype が、register 時の
+    /// 遡及マッチで `archetypeMatches` に追加されることを確認します
+    /// (addSystem を最初のフレーム後に呼ぶことで register を遅らせます)。
+    @Test func registerRetroactivelyMatchesExistingArchetypes() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.spawn()
+            .addComponent(ComponentA(value: 3))
+
+        // Query 未登録のままフレームを回し、Archetype を先に生成します。
+        world.update(currentTime: 0)
+
+        var observed = [Int]()
+        world.addSystem(.update) { (query: Query<ComponentA>) in
+            guard observed.isEmpty else { return }
+            query.update { component in
+                observed.append(component.value)
+            }
+        }
+
+        // register 時の遡及マッチで既存 Archetype が見えています。
+        let query = try #require(Query<ComponentA>.getParameter(from: world.worldStorage))
+        #expect(query.archetypeMatches.count == 1)
+
+        world.update(currentTime: 1)
+
+        #expect(observed == [3])
+    }
+
+    // MARK: - despawn の反映 (要件 1-2 の Query ビュー)
+
+    /// ON: despawn された entity が以降のイテレーションと `components(forEntity:)` から
+    /// 除外されることを確認します。
+    @Test func despawnedEntityIsNoLongerIterated() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+
+        var perFrame = [[Int]]()
+        world.addSystem(.update) { (query: Query<ComponentA>) in
+            var values = [Int]()
+            query.update { component in
+                values.append(component.value)
+            }
+            perFrame.append(values)
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        commands.despawn(entity: entity)
+        world.update(currentTime: 2)
+
+        #expect(perFrame == [[1], []])
+
+        let query = try #require(Query<ComponentA>.getParameter(from: world.worldStorage))
+        #expect(query.components(forEntity: entity) == nil)
+    }
+
+    // MARK: - OFF 経路の維持 (要件 4-1)
+
+    /// OFF: 従来の Query の挙動(イテレーション・変更の永続化・entity 指定取得)が
+    /// 影響を受けないことを確認します(完全な保証は既存テストスイート全体の通過によります)。
+    @Test func offWorldQueryKeepsCurrentBehavior() throws {
+        let world = World()
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+
+        var readBack = [Int?]()
+        world.addSystem(.update) { (query: Query<ComponentA>) in
+            readBack.append(query.components(forEntity: entity)?.value)
+            query.update { component in
+                component.value += 1
+            }
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+        world.update(currentTime: 2)
+
+        #expect(readBack == [1, 2])
+    }
+}

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeQueryTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeQueryTests.swift
@@ -271,4 +271,157 @@ struct ArchetypeQueryTests {
 
         #expect(readBack == [1, 2])
     }
+
+    // MARK: - 新旧パラメタライズ統合テスト (タスク 7.1)
+
+    /// 両バックエンド: 要求型集合の部分集合マッチが一致します(要件 2-1, 2-2)。
+    /// `Query<A>` は「A のみ」「A + B」の両方を、`Query2<A, B>` は「A + B」のみを対象とします。
+    @Test(arguments: WorldBackend.allCases)
+    func queryMembershipMatchesRequiredTypeSet(backend: WorldBackend) {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        commands.spawn()
+            .addComponent(ComponentA(value: 1))
+        commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .addComponent(ComponentB(text: "both"))
+        commands.spawn()
+            .addComponent(ComponentB(text: "onlyB"))
+
+        var observedA = [Int]()
+        var observedAB = [Int]()
+        world
+            .addSystem(.update) { (query: Query<ComponentA>) in
+                guard observedA.isEmpty else { return }
+                query.update { component in
+                    observedA.append(component.value)
+                }
+            }
+            .addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+                guard observedAB.isEmpty else { return }
+                query.update { a, _ in
+                    observedAB.append(a.value)
+                }
+            }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        #expect(observedA.sorted() == [1, 2])
+        #expect(observedAB == [2])
+    }
+
+    /// 両バックエンド: 型パラメータの記述順が異なる `Query2<A, B>` / `Query2<B, A>` が
+    /// 同一の entity 集合を対象とします(要件 2-3)。
+    @Test(arguments: WorldBackend.allCases)
+    func typeOrderDoesNotChangeMatchedEntitySet(backend: WorldBackend) {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .addComponent(ComponentB(text: "p"))
+        commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .addComponent(ComponentB(text: "q"))
+        commands.spawn()
+            .addComponent(ComponentA(value: 3))
+
+        var observedAB = Set<Int>()
+        var observedBA = Set<Int>()
+        world
+            .addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+                query.update { a, _ in
+                    observedAB.insert(a.value)
+                }
+            }
+            .addSystem(.update) { (query: Query2<ComponentB, ComponentA>) in
+                query.update { _, a in
+                    observedBA.insert(a.value)
+                }
+            }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        #expect(observedAB == [1, 2])
+        #expect(observedBA == observedAB)
+    }
+
+    /// 両バックエンド: `update(_:)` での変更が同一フレーム内の別 Query と
+    /// `components(forEntity:)` の両方から見えます(要件 2-4)。
+    @Test(arguments: WorldBackend.allCases)
+    func mutationIsVisibleToOtherQueryAndComponentsForEntity(backend: WorldBackend) throws {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .addComponent(ComponentB(text: "b"))
+            .id()
+
+        var observedByOtherQuery = [Int]()
+        world
+            .addSystem(.update) { (query: Query<ComponentA>) in
+                query.update { component in
+                    component.value += 10
+                }
+            }
+            .addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+                query.update { a, _ in
+                    observedByOtherQuery.append(a.value)
+                }
+            }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        // 先行システムの変更が同一フレームの後続システム(別 Query)から見えます。
+        #expect(observedByOtherQuery == [11])
+
+        // `components(forEntity:)` からも変更後の値が見えます。
+        let query = try #require(Query<ComponentA>.getParameter(from: world.worldStorage))
+        #expect(query.components(forEntity: entity) == ComponentA(value: 11))
+    }
+
+    /// 両バックエンド: `update(_:_:)` は対象 entity のみを更新し、対象型を持たない
+    /// entity への `components(forEntity:)` / `update(_:_:)` は何も返しません
+    /// (要件 2-7 の両バックエンド回帰)。
+    @Test(arguments: WorldBackend.allCases)
+    func targetedUpdateAndComponentsForEntityNonMatch(backend: WorldBackend) throws {
+        let world = backend.makeWorld()
+        let commands = world.worldStorage.commands
+
+        let target = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        let other = commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .id()
+        let onlyB = commands.spawn()
+            .addComponent(ComponentB(text: "b"))
+            .id()
+
+        // Query を register するためのシステムです(内容は使いません)。
+        world.addSystem(.update) { (_: Query<ComponentA>) in }
+        world.update(currentTime: 0)
+
+        let query = try #require(Query<ComponentA>.getParameter(from: world.worldStorage))
+
+        // 対象 entity のみが更新され、他の entity は影響を受けません。
+        query.update(target) { component in
+            component.value = 10
+        }
+        #expect(query.components(forEntity: target) == ComponentA(value: 10))
+        #expect(query.components(forEntity: other) == ComponentA(value: 2))
+
+        // 対象型を持たない entity は nil / no-op です。
+        #expect(query.components(forEntity: onlyB) == nil)
+        var nonMatchTouched = false
+        query.update(onlyB) { _ in
+            nonMatchTouched = true
+        }
+        #expect(!nonMatchTouched)
+    }
 }

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeStagingTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeStagingTests.swift
@@ -1,0 +1,83 @@
+//
+//  ArchetypeStagingTests.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+@testable import ECS
+import Testing
+
+struct ArchetypeStagingTests {
+
+    struct ValueComponent: Component, Equatable {
+        let value: Int
+    }
+
+    struct NameComponent: Component, Equatable {
+        let name: String
+    }
+
+    @Test func componentTypeKeyMatchesComponentType() {
+        let ref = ComponentRef(value: ValueComponent(value: 42))
+        let insertable: ArchetypeInsertable = ref
+        #expect(insertable.componentTypeKey == ObjectIdentifier(ValueComponent.self))
+        #expect(insertable.componentTypeKey != ObjectIdentifier(NameComponent.self))
+    }
+
+    @Test func makeColumnPrototypeReturnsEmptyColumnOfComponentType() {
+        let ref = ComponentRef(value: ValueComponent(value: 42))
+        let insertable: ArchetypeInsertable = ref
+        let prototype = insertable.makeColumnPrototype()
+        #expect(prototype.count == 0)
+        #expect(prototype is Column<ValueComponent>)
+    }
+
+    @Test func appendValueAppendsCurrentValueToColumn() {
+        let ref = ComponentRef(value: ValueComponent(value: 1))
+        // 現在値(最後に書き込まれた値)が追加されることを確認します.
+        ref.value = ValueComponent(value: 2)
+        let insertable: ArchetypeInsertable = ref
+        let column = Column<ValueComponent>()
+        insertable.appendValue(to: column)
+        insertable.appendValue(to: column)
+        #expect(column.data == [ValueComponent(value: 2), ValueComponent(value: 2)])
+    }
+
+    @Test func enumerateInsertablesFromRecordSkipsEntityEntry() {
+        // 旧 spawn 経路(Commands.spawn)と同じ手順で record を組み立てます.
+        let entity = Entity(slot: 0, generation: 0)
+        let record = EntityRecordRef(entity: entity)
+        record.map.body[ObjectIdentifier(Entity.self)] = ImmutableRef(value: entity)
+        record.addComponent(ValueComponent(value: 10))
+        record.addComponent(NameComponent(name: "a"))
+
+        let insertables = record.archetypeInsertables()
+
+        // Entity エントリ(ImmutableRef)は適合しないため, コンポーネント 2 件のみが列挙されます.
+        #expect(insertables.count == 2)
+        let keys = Set(insertables.map { $0.componentTypeKey })
+        #expect(keys == [
+            ObjectIdentifier(ValueComponent.self),
+            ObjectIdentifier(NameComponent.self),
+        ])
+        #expect(!keys.contains(ObjectIdentifier(Entity.self)))
+    }
+
+    @Test func enumeratedInsertablesCanBuildAndFillColumns() throws {
+        let entity = Entity(slot: 1, generation: 0)
+        let record = EntityRecordRef(entity: entity)
+        record.map.body[ObjectIdentifier(Entity.self)] = ImmutableRef(value: entity)
+        record.addComponent(ValueComponent(value: 7))
+
+        let insertables = record.archetypeInsertables()
+        #expect(insertables.count == 1)
+        let insertable = try #require(insertables.first)
+
+        let column = insertable.makeColumnPrototype()
+        insertable.appendValue(to: column)
+        #expect(column.count == 1)
+        let typed = try #require(column as? Column<ValueComponent>)
+        #expect(typed.data == [ValueComponent(value: 7)])
+    }
+}

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeStorageTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeStorageTests.swift
@@ -1,0 +1,220 @@
+//
+//  ArchetypeStorageTests.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+@testable import ECS
+import Testing
+
+struct ArchetypeStorageTests {
+
+    struct ComponentA: Component, Equatable {
+        let value: Int
+    }
+
+    struct ComponentB: Component, Equatable {
+        let name: String
+    }
+
+    /// 通知された Archetype と storage を記録するテスト用オブザーバです。
+    final class RecordingObserver: ArchetypeObserver {
+        var createdArchetypes = [Archetype]()
+        var notifiedStorages = [ArchetypeStorageRef]()
+
+        func archetypeCreated(_ archetype: Archetype, storage: ArchetypeStorageRef) {
+            self.createdArchetypes.append(archetype)
+            self.notifiedStorages.append(storage)
+        }
+    }
+
+    // MARK: - typeID
+
+    @Test func typeIDReturnsSameIDForSameKey() {
+        let storage = ArchetypeStorageRef()
+
+        let idA0 = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let idB = storage.typeID(for: ObjectIdentifier(ComponentB.self))
+        let idA1 = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+
+        #expect(idA0 == idA1)
+        #expect(idA0 != idB)
+    }
+
+    // MARK: - findOrCreate
+
+    @Test func findOrCreateReturnsSameInstanceForSameKeyEvenFromDifferentIDOrder() {
+        let storage = ArchetypeStorageRef()
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let idB = storage.typeID(for: ObjectIdentifier(ComponentB.self))
+
+        let first = storage.findOrCreate(
+            key: ArchetypeKey(sorting: [idA, idB]),
+            prototypes: [Column<ComponentA>(), Column<ComponentB>()]
+        )
+        let unusedPrototypes: [AnyColumn] = [Column<ComponentA>(), Column<ComponentB>()]
+        let second = storage.findOrCreate(
+            key: ArchetypeKey(sorting: [idB, idA]),
+            prototypes: unusedPrototypes
+        )
+
+        #expect(first === second)
+        #expect(storage.archetypes.count == 1)
+        // 既存 Archetype に 2 回目の prototypes が与えられていない
+        #expect(!second.columns.contains { column in
+            unusedPrototypes.contains { $0 === column }
+        })
+    }
+
+    @Test func findOrCreateCreatesNewArchetypeForDifferentKey() {
+        let storage = ArchetypeStorageRef()
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let idB = storage.typeID(for: ObjectIdentifier(ComponentB.self))
+        let keyAB = ArchetypeKey(sorting: [idA, idB])
+        let keyA = ArchetypeKey(sorting: [idA])
+
+        let archetypeAB = storage.findOrCreate(
+            key: keyAB,
+            prototypes: [Column<ComponentA>(), Column<ComponentB>()]
+        )
+        let archetypeA = storage.findOrCreate(
+            key: keyA,
+            prototypes: [Column<ComponentA>()]
+        )
+
+        #expect(archetypeAB !== archetypeA)
+        #expect(storage.archetypes.count == 2)
+        #expect(storage.byKey[keyAB] === archetypeAB)
+        #expect(storage.byKey[keyA] === archetypeA)
+    }
+
+    // MARK: - Observer
+
+    @Test func observerIsNotifiedOncePerCreationAndNotOnReuse() {
+        let storage = ArchetypeStorageRef()
+        let observer = RecordingObserver()
+        storage.observers.append(observer)
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let keyA = ArchetypeKey(sorting: [idA])
+
+        let created = storage.findOrCreate(key: keyA, prototypes: [Column<ComponentA>()])
+        let reused = storage.findOrCreate(key: keyA, prototypes: [Column<ComponentA>()])
+
+        #expect(reused === created)
+        #expect(observer.createdArchetypes.count == 1)
+        #expect(observer.createdArchetypes.first === created)
+        #expect(observer.notifiedStorages.first === storage)
+    }
+
+    @Test func everyObserverIsNotifiedForEachCreation() {
+        let storage = ArchetypeStorageRef()
+        let observer0 = RecordingObserver()
+        let observer1 = RecordingObserver()
+        storage.observers.append(observer0)
+        storage.observers.append(observer1)
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let idB = storage.typeID(for: ObjectIdentifier(ComponentB.self))
+
+        let archetypeA = storage.findOrCreate(
+            key: ArchetypeKey(sorting: [idA]),
+            prototypes: [Column<ComponentA>()]
+        )
+        let archetypeAB = storage.findOrCreate(
+            key: ArchetypeKey(sorting: [idA, idB]),
+            prototypes: [Column<ComponentA>(), Column<ComponentB>()]
+        )
+
+        for observer in [observer0, observer1] {
+            #expect(observer.createdArchetypes.count == 2)
+            #expect(observer.createdArchetypes.first === archetypeA)
+            #expect(observer.createdArchetypes.last === archetypeAB)
+        }
+    }
+
+    // MARK: - entityIndex
+
+    @Test func locationReturnsRegisteredLocationAndNilAfterRemoval() throws {
+        let storage = ArchetypeStorageRef()
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let archetype = storage.findOrCreate(
+            key: ArchetypeKey(sorting: [idA]),
+            prototypes: [Column<ComponentA>()]
+        )
+        let entity = Entity(slot: 0, generation: 0)
+
+        storage.setLocation(EntityLocation(archetype: archetype, row: 3), forEntity: entity)
+
+        let location = try #require(storage.location(of: entity))
+        #expect(location.archetype === archetype)
+        #expect(location.row == 3)
+
+        storage.removeLocation(of: entity)
+        #expect(storage.location(of: entity) == nil)
+    }
+
+    @Test func locationReturnsNilForUnregisteredEntity() {
+        let storage = ArchetypeStorageRef()
+
+        // sparse が一度も伸びていないスロットでもクラッシュせず nil を返す
+        #expect(storage.location(of: Entity(slot: 99, generation: 0)) == nil)
+    }
+
+    // MARK: - Generation check(要件 1-4)
+
+    @Test func locationReturnsNilForNewerGenerationQuery() throws {
+        let storage = ArchetypeStorageRef()
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let archetype = storage.findOrCreate(
+            key: ArchetypeKey(sorting: [idA]),
+            prototypes: [Column<ComponentA>()]
+        )
+        let registered = Entity(slot: 0, generation: 0)
+
+        storage.setLocation(EntityLocation(archetype: archetype, row: 0), forEntity: registered)
+
+        // 登録済み世代では取得できる
+        _ = try #require(storage.location(of: registered))
+        // 同一スロットの新しい世代では取得できない
+        #expect(storage.location(of: Entity(slot: 0, generation: 1)) == nil)
+    }
+
+    @Test func locationReturnsNilForStaleGenerationAfterSlotReuse() throws {
+        let storage = ArchetypeStorageRef()
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let archetype = storage.findOrCreate(
+            key: ArchetypeKey(sorting: [idA]),
+            prototypes: [Column<ComponentA>()]
+        )
+        let staleEntity = Entity(slot: 0, generation: 0)
+        let reusedEntity = Entity(slot: 0, generation: 1)
+
+        // generation 0 の spawn で sparse を伸ばし、despawn 後にスロットを再利用する
+        storage.setLocation(EntityLocation(archetype: archetype, row: 0), forEntity: staleEntity)
+        storage.removeLocation(of: staleEntity)
+        storage.setLocation(EntityLocation(archetype: archetype, row: 5), forEntity: reusedEntity)
+
+        // 古い世代の entity では取得できない
+        #expect(storage.location(of: staleEntity) == nil)
+        // 再利用後の世代では取得できる
+        let location = try #require(storage.location(of: reusedEntity))
+        #expect(location.row == 5)
+    }
+
+    @Test func removeLocationIgnoresMismatchedGeneration() throws {
+        let storage = ArchetypeStorageRef()
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let archetype = storage.findOrCreate(
+            key: ArchetypeKey(sorting: [idA]),
+            prototypes: [Column<ComponentA>()]
+        )
+        let registered = Entity(slot: 0, generation: 0)
+
+        storage.setLocation(EntityLocation(archetype: archetype, row: 0), forEntity: registered)
+        // 世代が一致しない削除要求は無視される
+        storage.removeLocation(of: Entity(slot: 0, generation: 1))
+
+        _ = try #require(storage.location(of: registered))
+    }
+
+}

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeTests.swift
@@ -1,0 +1,136 @@
+//
+//  ArchetypeTests.swift
+//
+//
+//  Created by rrbox on 2026/07/06.
+//
+
+@testable import ECS
+import Testing
+
+struct ArchetypeTests {
+
+    struct ComponentA: Component, Equatable {
+        let value: Int
+    }
+
+    struct ComponentB: Component, Equatable {
+        let name: String
+    }
+
+    // MARK: - Helpers
+
+    /// [A, B] の 2 カラム構成の Archetype と型 ID を生成します。
+    static func makeArchetypeAB() -> (archetype: Archetype, idA: ComponentTypeID, idB: ComponentTypeID) {
+        let registry = ComponentTypeRegistry()
+        let idA = registry.typeID(for: ObjectIdentifier(ComponentA.self))
+        let idB = registry.typeID(for: ObjectIdentifier(ComponentB.self))
+        let key = ArchetypeKey(sorting: [idA, idB])
+        let archetype = Archetype(key: key, columns: [Column<ComponentA>(), Column<ComponentB>()])
+        return (archetype, idA, idB)
+    }
+
+    /// (entity, A, B) の 1 行を archetype に追加します。
+    static func appendRow(to archetype: Archetype, entity: Entity, a: ComponentA, b: ComponentB) {
+        archetype.appendRow(entity: entity) { columns in
+            (columns[0] as! Column<ComponentA>).append(a)
+            (columns[1] as! Column<ComponentB>).append(b)
+        }
+    }
+
+    // MARK: - ArchetypeKey
+
+    @Test func keyFromUnsortedInputEqualsKeyFromSortedInput() {
+        let id0 = ComponentTypeID(value: 0)
+        let id1 = ComponentTypeID(value: 1)
+        let id2 = ComponentTypeID(value: 2)
+
+        let sorted = ArchetypeKey(sorting: [id0, id1, id2])
+        let unsorted = ArchetypeKey(sorting: [id2, id0, id1])
+
+        #expect(sorted == unsorted)
+        #expect(sorted.hashValue == unsorted.hashValue)
+        #expect(unsorted.ids == [id0, id1, id2])
+    }
+
+    // MARK: - Archetype init / column(of:)
+
+    @Test func columnOfReturnsParallelColumnForEachTypeID() throws {
+        let (archetype, idA, idB) = Self.makeArchetypeAB()
+
+        let columnA = try #require(archetype.column(of: idA))
+        let columnB = try #require(archetype.column(of: idB))
+        #expect(columnA is Column<ComponentA>)
+        #expect(columnB is Column<ComponentB>)
+        #expect(columnA !== columnB)
+    }
+
+    @Test func columnOfReturnsNilForAbsentTypeID() {
+        let (archetype, idA, idB) = Self.makeArchetypeAB()
+
+        let absent = ComponentTypeID(value: max(idA.value, idB.value) + 1)
+        #expect(archetype.column(of: absent) == nil)
+    }
+
+    // MARK: - swapRemoveRow
+
+    @Test func swapRemoveMiddleRowKeepsEntitiesAndColumnsInSyncAndReturnsFiller() throws {
+        let (archetype, idA, idB) = Self.makeArchetypeAB()
+        let e0 = Entity(slot: 0, generation: 0)
+        let e1 = Entity(slot: 1, generation: 0)
+        let e2 = Entity(slot: 2, generation: 0)
+        Self.appendRow(to: archetype, entity: e0, a: ComponentA(value: 10), b: ComponentB(name: "a"))
+        Self.appendRow(to: archetype, entity: e1, a: ComponentA(value: 20), b: ComponentB(name: "b"))
+        Self.appendRow(to: archetype, entity: e2, a: ComponentA(value: 30), b: ComponentB(name: "c"))
+
+        let filler = archetype.swapRemoveRow(1)
+
+        // 末尾行(e2)が row 1 を埋めるために移動し、その entity が返る
+        #expect(filler == e2)
+        #expect(archetype.entities == [e0, e2])
+
+        // 全カラムが entities と並行に swap-remove されている
+        let columnA = try #require(archetype.column(of: idA) as? Column<ComponentA>)
+        let columnB = try #require(archetype.column(of: idB) as? Column<ComponentB>)
+        #expect(columnA.data == [ComponentA(value: 10), ComponentA(value: 30)])
+        #expect(columnB.data == [ComponentB(name: "a"), ComponentB(name: "c")])
+    }
+
+    @Test func swapRemoveLastRowReturnsNil() throws {
+        let (archetype, idA, idB) = Self.makeArchetypeAB()
+        let e0 = Entity(slot: 0, generation: 0)
+        let e1 = Entity(slot: 1, generation: 0)
+        Self.appendRow(to: archetype, entity: e0, a: ComponentA(value: 1), b: ComponentB(name: "a"))
+        Self.appendRow(to: archetype, entity: e1, a: ComponentA(value: 2), b: ComponentB(name: "b"))
+
+        let filler = archetype.swapRemoveRow(1)
+
+        // 末尾行の削除では穴埋めが発生しないため nil
+        #expect(filler == nil)
+        #expect(archetype.entities == [e0])
+        let columnA = try #require(archetype.column(of: idA) as? Column<ComponentA>)
+        let columnB = try #require(archetype.column(of: idB) as? Column<ComponentB>)
+        #expect(columnA.data == [ComponentA(value: 1)])
+        #expect(columnB.data == [ComponentB(name: "a")])
+    }
+
+    @Test func swapRemoveOnlyRowLeavesArchetypeEmpty() throws {
+        let (archetype, idA, idB) = Self.makeArchetypeAB()
+        Self.appendRow(
+            to: archetype,
+            entity: Entity(slot: 0, generation: 0),
+            a: ComponentA(value: 1),
+            b: ComponentB(name: "a")
+        )
+
+        let filler = archetype.swapRemoveRow(0)
+
+        #expect(filler == nil)
+        #expect(archetype.entities.isEmpty)
+        let columnA = try #require(archetype.column(of: idA))
+        let columnB = try #require(archetype.column(of: idB))
+        #expect(columnA.count == 0)
+        #expect(columnB.count == 0)
+    }
+
+}

--- a/Tests/ecs-swiftTests/Archetype/ArchetypeWorldSpawnTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ArchetypeWorldSpawnTests.swift
@@ -1,0 +1,212 @@
+//
+//  ArchetypeWorldSpawnTests.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+@testable import ECS
+import Testing
+
+/// World 分岐点 2 (`push`) / 3 (`despawn`) の archetype storage ON 経路のテストです。
+///
+/// applyCommandsPhase の結線(タスク4.3)前のため、`push` / `despawn` を直接呼び、
+/// staging の適用は `applySpawnStaging()` を手動実行して検証します。
+struct ArchetypeWorldSpawnTests {
+
+    struct ComponentA: Component, Equatable {
+        let value: Int
+    }
+
+    /// 旧 spawn 経路(`Commands.spawn`)と同じ手順で staging record を組み立てます。
+    private func makeRecord(entity: Entity, value: Int? = nil) -> EntityRecordRef {
+        let record = EntityRecordRef(entity: entity)
+        record.map.body[ObjectIdentifier(Entity.self)] = ImmutableRef(value: entity)
+        if let value {
+            record.addComponent(ComponentA(value: value))
+        }
+        return record
+    }
+
+    /// entity を push し, staging を手動適用した ON の World を組み立てます。
+    private func makeAppliedWorld(values: [Int]) throws -> (World, ArchetypeStorageRef, [Entity]) {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let entities = values.indices.map { Entity(slot: $0, generation: 0) }
+        for (entity, value) in zip(entities, values) {
+            world.push(entityRecord: self.makeRecord(entity: entity, value: value))
+        }
+        storage.applySpawnStaging()
+        return (world, storage, entities)
+    }
+
+    private func columnA(of archetype: Archetype, storage: ArchetypeStorageRef) throws -> Column<ComponentA> {
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        return try #require(archetype.column(of: idA) as? Column<ComponentA>)
+    }
+
+    // MARK: - push (分岐点 2)
+
+    /// ON: push は staging queue へ積むのみで、Archetype への挿入や旧 chunk queue への
+    /// 追加は行われないことを確認します(挿入はタスク4.3 の applyCommandsPhase)。
+    @Test func pushOnArchetypeWorldStagesRecordWithoutInsertion() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let entity = Entity(slot: 0, generation: 0)
+        let record = self.makeRecord(entity: entity, value: 1)
+
+        world.push(entityRecord: record)
+
+        // staging queue に積まれるのみで、Archetype への挿入はまだ行われません。
+        #expect(storage.spawnStagingQueue.count == 1)
+        #expect(storage.spawnStagingQueue.first === record)
+        #expect(storage.archetypes.isEmpty)
+        #expect(storage.location(of: entity) == nil)
+
+        // 旧経路の chunk queue は使用されません。
+        let interface = try #require(
+            world.worldStorage.chunkStorageRef.storage.valueRef(ofType: ChunkEntityInterface.self)?.body
+        )
+        #expect(interface.prespawnedEntityQueue.isEmpty)
+
+        // World の entity table への登録は共通処理として維持されます。
+        #expect(world.entityRecord(forEntity: entity) === record)
+    }
+
+    /// ON: `Spawned` イベントの発行が共通処理として維持されることを確認します(要件 1-6)。
+    @Test func pushOnArchetypeWorldStillEmitsSpawnedEvent() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let entity = Entity(slot: 0, generation: 0)
+
+        world.push(entityRecord: self.makeRecord(entity: entity))
+
+        let queue = try #require(world.worldStorage.eventStorage.eventQueue(typeOf: Spawned.self))
+        #expect(queue.eventWritingBuffer.map { $0.spawnedEntity } == [entity])
+    }
+
+    /// OFF: 従来どおり chunk queue に積まれ、archetype storage は存在しないことを確認します。
+    @Test func pushOnDefaultWorldUsesChunkQueue() throws {
+        let world = World()
+        let entity = Entity(slot: 0, generation: 0)
+        let record = self.makeRecord(entity: entity, value: 1)
+
+        world.push(entityRecord: record)
+
+        #expect(world.worldStorage.archetypeStorageRef == nil)
+        let interface = try #require(
+            world.worldStorage.chunkStorageRef.storage.valueRef(ofType: ChunkEntityInterface.self)?.body
+        )
+        #expect(interface.prespawnedEntityQueue.count == 1)
+        #expect(interface.prespawnedEntityQueue.first === record)
+    }
+
+    // MARK: - despawn (分岐点 3)
+
+    /// ON: 中間行の despawn で swap-remove が行われ、埋めた entity(filler)の
+    /// 行番号が補正されることを確認します。
+    @Test func despawnMiddleEntityCompactsRowsAndFixesFillerLocation() throws {
+        let (world, storage, entities) = try self.makeAppliedWorld(values: [10, 20, 30])
+        let archetype = try #require(storage.location(of: entities[1])).archetype
+
+        world.despawn(entity: entities[1])
+
+        // despawn した entity は所在・entity table の両方から消えます。
+        #expect(storage.location(of: entities[1]) == nil)
+        #expect(world.entityRecord(forEntity: entities[1]) == nil)
+
+        // 末尾の entity が row 1 を埋め、所在が補正されます。
+        #expect(archetype.entities == [entities[0], entities[2]])
+        let fillerLocation = try #require(storage.location(of: entities[2]))
+        #expect(fillerLocation.archetype === archetype)
+        #expect(fillerLocation.row == 1)
+        let location0 = try #require(storage.location(of: entities[0]))
+        #expect(location0.row == 0)
+
+        // カラムのデータも同期して詰められます。
+        let column = try self.columnA(of: archetype, storage: storage)
+        #expect(column.data == [ComponentA(value: 10), ComponentA(value: 30)])
+    }
+
+    /// ON: 末尾行の despawn(filler なし)が正しく処理されることを確認します。
+    @Test func despawnLastEntityRemovesRowWithoutFiller() throws {
+        let (world, storage, entities) = try self.makeAppliedWorld(values: [10, 20])
+        let archetype = try #require(storage.location(of: entities[1])).archetype
+
+        world.despawn(entity: entities[1])
+
+        #expect(storage.location(of: entities[1]) == nil)
+        #expect(archetype.entities == [entities[0]])
+        let location0 = try #require(storage.location(of: entities[0]))
+        #expect(location0.row == 0)
+        let column = try self.columnA(of: archetype, storage: storage)
+        #expect(column.data == [ComponentA(value: 10)])
+    }
+
+    /// ON: 唯一の行の despawn で Archetype が空になることを確認します。
+    @Test func despawnOnlyEntityLeavesEmptyArchetype() throws {
+        let (world, storage, entities) = try self.makeAppliedWorld(values: [10])
+        let archetype = try #require(storage.location(of: entities[0])).archetype
+
+        world.despawn(entity: entities[0])
+
+        #expect(storage.location(of: entities[0]) == nil)
+        #expect(archetype.entities.isEmpty)
+        let column = try self.columnA(of: archetype, storage: storage)
+        #expect(column.data.isEmpty)
+    }
+
+    /// ON: 未登録 entity の despawn が安全な no-op であることを確認します。
+    @Test func despawnUnknownEntityIsSafeNoOp() throws {
+        let (world, storage, entities) = try self.makeAppliedWorld(values: [10])
+
+        // slot が sparse の範囲外の entity。
+        world.despawn(entity: Entity(slot: 5, generation: 0))
+
+        let location0 = try #require(storage.location(of: entities[0]))
+        #expect(location0.row == 0)
+        #expect(location0.archetype.entities == [entities[0]])
+    }
+
+    /// ON: 同一 entity の二重 despawn が安全な no-op であることを確認します。
+    @Test func despawnTwiceIsSafeNoOp() throws {
+        let (world, storage, entities) = try self.makeAppliedWorld(values: [10, 20])
+        let archetype = try #require(storage.location(of: entities[0])).archetype
+
+        world.despawn(entity: entities[0])
+        world.despawn(entity: entities[0])
+
+        #expect(storage.location(of: entities[0]) == nil)
+        #expect(archetype.entities == [entities[1]])
+        let location1 = try #require(storage.location(of: entities[1]))
+        #expect(location1.row == 0)
+    }
+
+    /// ON: 世代不一致の entity への despawn が entityIndex を破壊しないことを確認します。
+    ///
+    /// World の entity table を経由すると別のバリデーションで停止するため、
+    /// entityIndex に stale な世代が残るケースをストレージ直接登録で構成します。
+    @Test func despawnStaleGenerationEntityIsSafeNoOp() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let entity = Entity(slot: 0, generation: 0)
+        storage.insert(record: self.makeRecord(entity: entity, value: 10))
+
+        // 同一 slot・別世代の entity に対する despawn は無視されます。
+        world.despawn(entity: Entity(slot: 0, generation: 1))
+
+        let location = try #require(storage.location(of: entity))
+        #expect(location.row == 0)
+        #expect(location.archetype.entities == [entity])
+    }
+
+    /// ON: Removed lifecycle への `pushDespawned` が共通処理として維持されることを
+    /// 確認します(要件 1-7)。
+    @Test func despawnOnArchetypeWorldStillPushesToRemovedLifecycle() throws {
+        let (world, _, entities) = try self.makeAppliedWorld(values: [10])
+        let receiver = try #require(world.worldStorage.eventStorage.removedEventReceiver())
+
+        world.despawn(entity: entities[0])
+
+        #expect(receiver.count == 1)
+    }
+}

--- a/Tests/ecs-swiftTests/Archetype/ColumnAccessTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ColumnAccessTests.swift
@@ -1,0 +1,144 @@
+//
+//  ColumnAccessTests.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+@testable import ECS
+import Testing
+
+struct ColumnAccessTests {
+
+    struct ComponentA: Component, Equatable {
+        var value: Int
+    }
+
+    struct ComponentB: Component, Equatable {
+        var name: String
+    }
+
+    /// テスト対象の Archetype には含まれないコンポーネント型です。
+    struct ComponentC: Component, Equatable {
+        var flag: Bool
+    }
+
+    // MARK: - Helpers
+
+    /// [A, B] の 2 カラム構成の Archetype とストレージを生成し、2 行を投入します。
+    static func makeStorageAndArchetypeAB() -> (storage: ArchetypeStorageRef, archetype: Archetype) {
+        let storage = ArchetypeStorageRef()
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let idB = storage.typeID(for: ObjectIdentifier(ComponentB.self))
+        let key = ArchetypeKey(sorting: [idA, idB])
+        let archetype = storage.findOrCreate(
+            key: key,
+            prototypes: [Column<ComponentA>(), Column<ComponentB>()]
+        )
+        appendRow(
+            to: archetype,
+            entity: Entity(slot: 0, generation: 0),
+            a: ComponentA(value: 10),
+            b: ComponentB(name: "a")
+        )
+        appendRow(
+            to: archetype,
+            entity: Entity(slot: 1, generation: 0),
+            a: ComponentA(value: 20),
+            b: ComponentB(name: "b")
+        )
+        return (storage, archetype)
+    }
+
+    /// (entity, A, B) の 1 行を archetype に追加します。
+    static func appendRow(to archetype: Archetype, entity: Entity, a: ComponentA, b: ComponentB) {
+        archetype.appendRow(entity: entity) { columns in
+            (columns[0] as! Column<ComponentA>).append(a)
+            (columns[1] as! Column<ComponentB>).append(b)
+        }
+    }
+
+    // MARK: - resolve
+
+    @Test func resolvePresentComponentTypeReturnsColumnAndReadsValues() throws {
+        let (storage, archetype) = Self.makeStorageAndArchetypeAB()
+
+        let access = try #require(ColumnAccess<ComponentA>.resolve(in: archetype, storage: storage))
+
+        // .column として解決され、保持カラムが公開される
+        let column = try #require(access.columnRef)
+        #expect(column.data == [ComponentA(value: 10), ComponentA(value: 20)])
+
+        // 行単位の読み出しがカラムの実データと一致する
+        #expect(access.value(at: 0, in: archetype) == ComponentA(value: 10))
+        #expect(access.value(at: 1, in: archetype) == ComponentA(value: 20))
+    }
+
+    @Test func resolveSecondComponentTypeReturnsItsOwnColumn() throws {
+        let (storage, archetype) = Self.makeStorageAndArchetypeAB()
+
+        let access = try #require(ColumnAccess<ComponentB>.resolve(in: archetype, storage: storage))
+
+        #expect(access.value(at: 0, in: archetype) == ComponentB(name: "a"))
+        #expect(access.value(at: 1, in: archetype) == ComponentB(name: "b"))
+    }
+
+    @Test func resolveAbsentComponentTypeReturnsNil() {
+        let (storage, archetype) = Self.makeStorageAndArchetypeAB()
+
+        // Archetype に含まれない型は「マッチしない」ことを表す nil を返す
+        #expect(ColumnAccess<ComponentC>.resolve(in: archetype, storage: storage) == nil)
+    }
+
+    @Test func resolveEntityTargetReturnsEntityCaseWithoutEntityColumn() throws {
+        let (storage, archetype) = Self.makeStorageAndArchetypeAB()
+
+        // Entity カラムは存在しないが、Entity ターゲットは .entity として解決される
+        let access = try #require(ColumnAccess<Entity>.resolve(in: archetype, storage: storage))
+
+        // .entity は保持カラムを持たない
+        #expect(access.columnRef == nil)
+
+        // 読み出しは archetype.entities から供給される
+        #expect(access.value(at: 0, in: archetype) == Entity(slot: 0, generation: 0))
+        #expect(access.value(at: 1, in: archetype) == Entity(slot: 1, generation: 0))
+    }
+
+    // MARK: - isEntity
+
+    @Test func isEntityIsTrueOnlyForEntityTarget() {
+        #expect(ColumnAccess<Entity>.isEntity)
+        #expect(!ColumnAccess<ComponentA>.isEntity)
+        #expect(!ColumnAccess<ComponentB>.isEntity)
+    }
+
+    // MARK: - write path
+
+    @Test func setValueThroughColumnAccessMutatesUnderlyingColumnData() throws {
+        let (storage, archetype) = Self.makeStorageAndArchetypeAB()
+        let access = try #require(ColumnAccess<ComponentA>.resolve(in: archetype, storage: storage))
+
+        access.setValue(ComponentA(value: 99), at: 1)
+
+        // 保持カラムは Archetype 内カラムと同一実体であるため、書き込みが反映される
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        let column = try #require(archetype.column(of: idA) as? Column<ComponentA>)
+        #expect(column.data == [ComponentA(value: 10), ComponentA(value: 99)])
+        #expect(access.value(at: 1, in: archetype) == ComponentA(value: 99))
+    }
+
+    @Test func setValueOnEntityAccessIsDiscardedWithoutCrash() throws {
+        let (storage, archetype) = Self.makeStorageAndArchetypeAB()
+        let access = try #require(ColumnAccess<Entity>.resolve(in: archetype, storage: storage))
+
+        // 現行 ImmutableRef の set no-op と同等: 書き込みは破棄され、クラッシュしない
+        access.setValue(Entity(slot: 42, generation: 7), at: 0)
+
+        #expect(archetype.entities == [
+            Entity(slot: 0, generation: 0),
+            Entity(slot: 1, generation: 0),
+        ])
+        #expect(access.value(at: 0, in: archetype) == Entity(slot: 0, generation: 0))
+    }
+
+}

--- a/Tests/ecs-swiftTests/Archetype/ColumnTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ColumnTests.swift
@@ -1,0 +1,143 @@
+//
+//  ColumnTests.swift
+//
+//
+//  Created by rrbox on 2026/07/06.
+//
+
+@testable import ECS
+import Testing
+
+struct ColumnTests {
+
+    struct ValueComponent: Component, Equatable {
+        let value: Int
+    }
+
+    final class Node {
+        var value: Int
+        init(value: Int) {
+            self.value = value
+        }
+    }
+
+    /// クラス参照を保持する非トリビアルなコンポーネント(Graphic<Node> 相当)。
+    struct NodeComponent: Component {
+        let node: Node
+    }
+
+    @Test func appendThenCountAndDataIntegrity() {
+        let column = Column<ValueComponent>()
+        #expect(column.count == 0)
+        column.append(ValueComponent(value: 10))
+        column.append(ValueComponent(value: 20))
+        column.append(ValueComponent(value: 30))
+        #expect(column.count == 3)
+        #expect(column.data == [
+            ValueComponent(value: 10),
+            ValueComponent(value: 20),
+            ValueComponent(value: 30),
+        ])
+    }
+
+    @Test func moveRowAppendsToTargetAndSwapRemovesFromSource() {
+        let source = Column<ValueComponent>()
+        source.append(ValueComponent(value: 1))  // a
+        source.append(ValueComponent(value: 2))  // b
+        source.append(ValueComponent(value: 3))  // c
+        let target = Column<ValueComponent>()
+        target.append(ValueComponent(value: 100))
+
+        source.moveRow(0, to: target)
+
+        // 移動した値が target 末尾に追加される
+        #expect(target.count == 2)
+        #expect(target.data == [
+            ValueComponent(value: 100),
+            ValueComponent(value: 1),
+        ])
+        // source は swap-remove で [a, b, c] → [c, b] になる
+        #expect(source.count == 2)
+        #expect(source.data == [
+            ValueComponent(value: 3),
+            ValueComponent(value: 2),
+        ])
+    }
+
+    @Test func moveLastRow() {
+        let source = Column<ValueComponent>()
+        source.append(ValueComponent(value: 1))
+        source.append(ValueComponent(value: 2))
+        let target = Column<ValueComponent>()
+
+        source.moveRow(1, to: target)
+
+        #expect(source.data == [ValueComponent(value: 1)])
+        #expect(target.data == [ValueComponent(value: 2)])
+    }
+
+    @Test func swapRemoveRowMovesLastIntoRemovedSlot() {
+        let column = Column<ValueComponent>()
+        column.append(ValueComponent(value: 1))  // a
+        column.append(ValueComponent(value: 2))  // b
+        column.append(ValueComponent(value: 3))  // c
+
+        column.swapRemoveRow(0)
+
+        // [a, b, c] → [c, b]
+        #expect(column.data == [
+            ValueComponent(value: 3),
+            ValueComponent(value: 2),
+        ])
+    }
+
+    @Test func swapRemoveLastRow() {
+        let column = Column<ValueComponent>()
+        column.append(ValueComponent(value: 1))
+        column.append(ValueComponent(value: 2))
+
+        column.swapRemoveRow(1)
+
+        #expect(column.data == [ValueComponent(value: 1)])
+    }
+
+    @Test func swapRemoveOnlyRowMakesColumnEmpty() {
+        let column = Column<ValueComponent>()
+        column.append(ValueComponent(value: 1))
+
+        column.swapRemoveRow(0)
+
+        #expect(column.count == 0)
+        #expect(column.data.isEmpty)
+    }
+
+    @Test func makeEmptyReturnsSameTypedEmptyColumnUsableAsMoveTarget() throws {
+        let source = Column<ValueComponent>()
+        source.append(ValueComponent(value: 42))
+
+        let empty = source.makeEmpty()
+        #expect(empty.count == 0)
+        #expect(empty is Column<ValueComponent>)
+
+        // makeEmpty で生成したカラムを moveRow の移動先として使用できる
+        source.moveRow(0, to: empty)
+        #expect(source.count == 0)
+        let typed = try #require(empty as? Column<ValueComponent>)
+        #expect(typed.data == [ValueComponent(value: 42)])
+    }
+
+    @Test func classReferencePreservedAcrossMoveRow() {
+        let node = Node(value: 0)
+        let source = Column<NodeComponent>()
+        source.append(NodeComponent(node: node))
+        let target = Column<NodeComponent>()
+
+        source.moveRow(0, to: target)
+
+        // 移動後も参照同一性が保たれ、元の参照経由の変更が観測できる
+        #expect(target.data[0].node === node)
+        node.value = 99
+        #expect(target.data[0].node.value == 99)
+    }
+
+}

--- a/Tests/ecs-swiftTests/Archetype/ComponentTypeIDTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ComponentTypeIDTests.swift
@@ -1,0 +1,58 @@
+//
+//  ComponentTypeIDTests.swift
+//
+//
+//  Created by rrbox on 2026/07/06.
+//
+
+@testable import ECS
+import Testing
+
+struct ComponentTypeIDTests {
+
+    struct ComponentA {}
+    struct ComponentB {}
+    struct ComponentC {}
+
+    @Test func sameTypeKeyReturnsSameID() {
+        let registry = ComponentTypeRegistry()
+        let first = registry.typeID(for: ObjectIdentifier(ComponentA.self))
+        let second = registry.typeID(for: ObjectIdentifier(ComponentA.self))
+        #expect(first == second)
+    }
+
+    @Test func differentTypeKeysReturnSequentialIDs() {
+        let registry = ComponentTypeRegistry()
+        let a = registry.typeID(for: ObjectIdentifier(ComponentA.self))
+        let b = registry.typeID(for: ObjectIdentifier(ComponentB.self))
+        let c = registry.typeID(for: ObjectIdentifier(ComponentC.self))
+        #expect(a.value == 0)
+        #expect(b.value == 1)
+        #expect(c.value == 2)
+        #expect(a != b)
+        #expect(b != c)
+    }
+
+    @Test func independentRegistriesNumberIndependently() {
+        let registry0 = ComponentTypeRegistry()
+        let registry1 = ComponentTypeRegistry()
+        // registry0 で先に別の型を採番しても、registry1 の採番には影響しない
+        _ = registry0.typeID(for: ObjectIdentifier(ComponentA.self))
+        _ = registry0.typeID(for: ObjectIdentifier(ComponentB.self))
+        let idInRegistry0 = registry0.typeID(for: ObjectIdentifier(ComponentC.self))
+        let idInRegistry1 = registry1.typeID(for: ObjectIdentifier(ComponentC.self))
+        #expect(idInRegistry0.value == 2)
+        #expect(idInRegistry1.value == 0)
+    }
+
+    @Test func comparableFollowsAssignmentOrder() {
+        let registry = ComponentTypeRegistry()
+        let a = registry.typeID(for: ObjectIdentifier(ComponentA.self))
+        let b = registry.typeID(for: ObjectIdentifier(ComponentB.self))
+        let c = registry.typeID(for: ObjectIdentifier(ComponentC.self))
+        #expect(a < b)
+        #expect(b < c)
+        #expect([c, a, b].sorted() == [a, b, c])
+    }
+
+}

--- a/Tests/ecs-swiftTests/Archetype/ExperimentalWorldTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/ExperimentalWorldTests.swift
@@ -1,0 +1,37 @@
+//
+//  ExperimentalWorldTests.swift
+//
+//
+//  Created by rrbox on 2026/07/07.
+//
+
+@testable import ECS
+import Testing
+
+struct ExperimentalWorldTests {
+
+    /// 既存の `World()` はオプションなし・archetype storage なしで初期化されることを確認します。
+    @Test func defaultInitHasNoExperimentalOptions() {
+        let world = World()
+        #expect(world.worldStorage.experimentalOptions == [])
+        #expect(world.worldStorage.archetypeStorageRef == nil)
+    }
+
+    /// `archetypeStorage` オプション指定時に `ArchetypeStorageRef` が生成されることを確認します。
+    @Test func archetypeStorageOptionCreatesArchetypeStorageRef() {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        #expect(world.worldStorage.experimentalOptions == [.archetypeStorage])
+        #expect(world.worldStorage.archetypeStorageRef != nil)
+    }
+
+    /// ON 時も `setUpChunkBuffer` が実行され、chunk buffer がパラメータレジストリとして
+    /// 維持されることを確認します(design.md 分岐点1)。
+    @Test func archetypeStorageOptionKeepsChunkBufferSetUp() {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        // setUpChunkBuffer() は ChunkEntityInterface を登録します。
+        #expect(world.worldStorage.chunkStorageRef.storage.valueRef(ofType: ChunkEntityInterface.self) != nil)
+    }
+
+    // NOTE: `WorldStorageRef.experimentalOptions` と `archetypeStorageRef` は `let` で宣言されるため、
+    // 初期化後の不変性はコンパイル時に保証されます(要件 4-4)。実行時テストは不要です。
+}

--- a/Tests/ecs-swiftTests/Archetype/SearchedEntityDiffTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/SearchedEntityDiffTests.swift
@@ -1,0 +1,536 @@
+//
+//  SearchedEntityDiffTests.swift
+//
+//
+//  Created by rrbox on 2026/07/08.
+//
+
+@testable import ECS
+import Testing
+
+/// searched entity 経路の差分トランザクション(`SearchedEntityDiffQueue` /
+/// `ComponentDiff`)のテストです(タスク 6.1)。
+///
+/// 同一型への重複差分の「後勝ち」正規化(要件 3-3)と、空 diff の no-op マーカー
+/// (要件 3-4)を検証します。
+struct SearchedEntityDiffTests {
+
+    struct ComponentA: Component, Equatable {
+        var value: Int
+    }
+
+    struct ComponentB: Component, Equatable {
+        var text: String
+    }
+
+    private let entity = Entity(slot: 0, generation: 0)
+
+    // MARK: - helpers
+
+    /// `.add` 差分から保持値を取り出します。`.remove` や型不一致の場合は nil です。
+    private func addValue<T: Component>(_ diff: ComponentDiff, as type: T.Type) -> T? {
+        guard case .add(let insertable) = diff else { return nil }
+        return (insertable as? ComponentRef<T>)?.value
+    }
+
+    /// `.remove` 差分から型キーを取り出します。`.add` の場合は nil です。
+    private func removeKey(_ diff: ComponentDiff) -> ObjectIdentifier? {
+        guard case .remove(let key) = diff else { return nil }
+        return key
+    }
+
+    // MARK: - 後勝ち正規化 (要件 3-3)
+
+    /// 同一型への add → remove は remove(後勝ち)に正規化されます。
+    @Test func addThenRemoveSameTypeNormalizesToRemove() {
+        let queue = SearchedEntityDiffQueue(entity: self.entity)
+        queue.diffs.append(.add(ComponentRef(value: ComponentA(value: 1))))
+        queue.diffs.append(.remove(ObjectIdentifier(ComponentA.self)))
+
+        let normalized = queue.normalizedDiffs()
+
+        #expect(normalized.count == 1)
+        #expect(self.removeKey(normalized[0]) == ObjectIdentifier(ComponentA.self))
+    }
+
+    /// 同一型への remove → add は add(後勝ち)に正規化され、値が保持されます。
+    @Test func removeThenAddSameTypeNormalizesToAdd() {
+        let queue = SearchedEntityDiffQueue(entity: self.entity)
+        queue.diffs.append(.remove(ObjectIdentifier(ComponentA.self)))
+        queue.diffs.append(.add(ComponentRef(value: ComponentA(value: 42))))
+
+        let normalized = queue.normalizedDiffs()
+
+        #expect(normalized.count == 1)
+        #expect(self.addValue(normalized[0], as: ComponentA.self) == ComponentA(value: 42))
+    }
+
+    /// 同一型への add → add は最後の値のみが残ります。
+    @Test func duplicateAddsKeepOnlyLastValue() {
+        let queue = SearchedEntityDiffQueue(entity: self.entity)
+        queue.diffs.append(.add(ComponentRef(value: ComponentA(value: 1))))
+        queue.diffs.append(.add(ComponentRef(value: ComponentA(value: 2))))
+
+        let normalized = queue.normalizedDiffs()
+
+        #expect(normalized.count == 1)
+        #expect(self.addValue(normalized[0], as: ComponentA.self) == ComponentA(value: 2))
+    }
+
+    // MARK: - 空 diff の no-op マーカー (要件 3-4)
+
+    /// diff が積まれていない queue は `diffs.isEmpty` が no-op マーカーとして機能し、
+    /// 正規化結果も空になります。
+    @Test func emptyDiffQueueIsNoOpMarker() {
+        let queue = SearchedEntityDiffQueue(entity: self.entity)
+
+        #expect(queue.diffs.isEmpty)
+        #expect(queue.normalizedDiffs().isEmpty)
+    }
+
+    // MARK: - 異なる型の差分の保存
+
+    /// 異なる型の差分は正規化で失われず、種別と値がすべて保持されます。
+    @Test func distinctTypesArePreservedByNormalization() {
+        let queue = SearchedEntityDiffQueue(entity: self.entity)
+        queue.diffs.append(.add(ComponentRef(value: ComponentA(value: 1))))
+        queue.diffs.append(.remove(ObjectIdentifier(ComponentB.self)))
+
+        let normalized = queue.normalizedDiffs()
+
+        #expect(normalized.count == 2)
+        #expect(self.addValue(normalized[0], as: ComponentA.self) == ComponentA(value: 1))
+        #expect(self.removeKey(normalized[1]) == ObjectIdentifier(ComponentB.self))
+    }
+
+    // MARK: - EntityCommands フックと Commands.entity(_) の分岐 (要件 3-2)
+
+    /// テスト用の bundle です。`@Bundle` マクロと同じ `BundleProtocol` の
+    /// 公開面(record への addComponent)を手書きで実装しています。
+    struct TestBundle: BundleProtocol {
+        let a: ComponentA
+        let b: ComponentB
+
+        func addComponent(forEntity record: EntityRecordRef) {
+            record.addComponent(self.a)
+            record.addComponent(self.b)
+        }
+    }
+
+    /// `Commands.entityTransactions` から diff queue を取り出します。
+    private func diffQueues(in commands: Commands) -> [SearchedEntityDiffQueue] {
+        commands.entityTransactions.compactMap { $0 as? SearchedEntityDiffQueue }
+    }
+
+    /// ON: `commands.entity(e).addComponent(...)` が add 差分として蓄積されます
+    /// (公開 API は現行と同一、要件 3-2)。
+    @Test func entityCommandsOnArchetypeWorldEnqueuesAddDiff() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.entity(self.entity)
+            .addComponent(ComponentA(value: 3))
+
+        let queue = try #require(self.diffQueues(in: commands).first)
+        #expect(queue.entity == self.entity)
+        #expect(queue.diffs.count == 1)
+        #expect(self.addValue(queue.diffs[0], as: ComponentA.self) == ComponentA(value: 3))
+    }
+
+    /// ON: `removeComponent(ofType:)` が remove 差分として蓄積されます。
+    @Test func entityCommandsOnArchetypeWorldEnqueuesRemoveDiff() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.entity(self.entity)
+            .removeComponent(ofType: ComponentA.self)
+
+        let queue = try #require(self.diffQueues(in: commands).first)
+        #expect(queue.diffs.count == 1)
+        #expect(self.removeKey(queue.diffs[0]) == ObjectIdentifier(ComponentA.self))
+    }
+
+    /// ON: `addBundle` が bundle 内の各コンポーネントの add 差分へ展開されます
+    /// (`@Bundle` 互換の維持)。
+    @Test func entityCommandsOnArchetypeWorldExpandsBundleIntoAddDiffs() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.entity(self.entity)
+            .addBundle(TestBundle(a: ComponentA(value: 5), b: ComponentB(text: "b")))
+
+        let queue = try #require(self.diffQueues(in: commands).first)
+        #expect(queue.diffs.count == 2)
+
+        // record(Dictionary)経由の展開のため差分の順序は不定です。型キー集合と値で検証します。
+        let addedValuesA = queue.diffs.compactMap { self.addValue($0, as: ComponentA.self) }
+        let addedValuesB = queue.diffs.compactMap { self.addValue($0, as: ComponentB.self) }
+        #expect(addedValuesA == [ComponentA(value: 5)])
+        #expect(addedValuesB == [ComponentB(text: "b")])
+    }
+
+    /// ON: メソッドチェーン(公開 API 不変)で複数の差分が同一 queue に蓄積されます。
+    @Test func entityCommandsOnArchetypeWorldChainsIntoSingleQueue() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+
+        commands.entity(self.entity)
+            .addComponent(ComponentA(value: 1))
+            .removeComponent(ofType: ComponentB.self)
+
+        let queues = self.diffQueues(in: commands)
+        #expect(queues.count == 1)
+        #expect(queues.first?.diffs.count == 2)
+    }
+
+    /// OFF: `commands.entity(e)` は従来どおり `SearchedEntityCommandQueue` に
+    /// `EntityCommand` を積みます(diff queue は生成されません、要件 4-1)。
+    @Test func entityCommandsOnLegacyWorldKeepsCommandQueuePath() throws {
+        let world = World()
+        let commands = world.worldStorage.commands
+
+        commands.entity(self.entity)
+            .addComponent(ComponentA(value: 1))
+            .removeComponent(ofType: ComponentA.self)
+
+        #expect(self.diffQueues(in: commands).isEmpty)
+
+        let queue = try #require(
+            commands.entityTransactions
+                .compactMap { $0 as? SearchedEntityCommandQueue }
+                .first
+        )
+        #expect(queue.entity == self.entity)
+        #expect(queue.queue.count == 2)
+        #expect(queue.queue[0] is AddComponent<ComponentA>)
+        #expect(queue.queue[1] is RemoveComponent<ComponentA>)
+    }
+
+    // MARK: - ストレージ (diffQueues)
+
+    /// `ArchetypeStorageRef` は diff queue の蓄積先(`diffQueues`)を持ちます
+    /// (旧 updatedEntityQueue 相当、design.md ArchetypeStorageRef)。
+    @Test func archetypeStorageRefHasDiffQueuesStorage() {
+        let storage = ArchetypeStorageRef()
+
+        #expect(storage.diffQueues.isEmpty)
+
+        let queue = SearchedEntityDiffQueue(entity: self.entity)
+        storage.diffQueues.append(queue)
+
+        #expect(storage.diffQueues.count == 1)
+        #expect(storage.diffQueues.first === queue)
+    }
+
+    // MARK: - flush 適用: archetype 移動 (タスク 6.3, 要件 1-3, 3-4, 5-1)
+
+    struct ComponentC: Component, Equatable {
+        var flag: Bool
+    }
+
+    private func column<T: Component>(
+        of type: T.Type,
+        in archetype: Archetype,
+        storage: ArchetypeStorageRef
+    ) throws -> Column<T> {
+        let id = storage.typeID(for: ObjectIdentifier(T.self))
+        return try #require(archetype.column(of: id) as? Column<T>)
+    }
+
+    /// ON: `addComponent` により entity が次フレームで Query の対象に入ります(要件 1-3)。
+    @Test func addComponentMovesEntityIntoQueryScopeOnNextFrame() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+
+        var observedPerFrame = [[Int]]()
+        world.addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+            var values = [Int]()
+            query.update { a, _ in values.append(a.value) }
+            observedPerFrame.append(values)
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        commands.entity(entity).addComponent(ComponentB(text: "b"))
+        world.update(currentTime: 2)
+
+        // B 追加前のフレームでは対象外、追加が適用された後のフレームで対象に入ります。
+        #expect(observedPerFrame == [[], [1]])
+
+        // 移動後の所在と両カラムの値が正しいことを確認します。
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let location = try #require(storage.location(of: entity))
+        let columnA = try self.column(of: ComponentA.self, in: location.archetype, storage: storage)
+        let columnB = try self.column(of: ComponentB.self, in: location.archetype, storage: storage)
+        #expect(columnA.data[location.row] == ComponentA(value: 1))
+        #expect(columnB.data[location.row] == ComponentB(text: "b"))
+
+        // diff queue は適用後にクリアされます。
+        #expect(storage.diffQueues.isEmpty)
+    }
+
+    /// ON: `removeComponent` により entity が Query の対象から外れます(要件 1-3)。
+    /// 削除されなかったコンポーネントの値は移動後も保持されます。
+    @Test func removeComponentMovesEntityOutOfQueryScope() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let commands = world.worldStorage.commands
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 7))
+            .addComponent(ComponentB(text: "x"))
+            .id()
+
+        var observedPerFrame = [[Int]]()
+        world.addSystem(.update) { (query: Query2<ComponentA, ComponentB>) in
+            var values = [Int]()
+            query.update { a, _ in values.append(a.value) }
+            observedPerFrame.append(values)
+        }
+
+        world.update(currentTime: 0)
+        world.update(currentTime: 1)
+
+        commands.entity(entity).removeComponent(ofType: ComponentB.self)
+        world.update(currentTime: 2)
+
+        #expect(observedPerFrame == [[7], []])
+
+        // 移動先は {A} のみの Archetype で、A の値は保持されます。
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let location = try #require(storage.location(of: entity))
+        #expect(location.archetype.key.ids.count == 1)
+        let columnA = try self.column(of: ComponentA.self, in: location.archetype, storage: storage)
+        #expect(columnA.data[location.row] == ComponentA(value: 7))
+    }
+
+    /// ON: 既に持っている型への `addComponent` は Archetype 移動を起こさず、
+    /// その行の値を上書きします(target key が同一になるエッジケース)。
+    @Test func addComponentOfExistingTypeOverwritesValueInPlace() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+
+        let before = try #require(storage.location(of: entity))
+        let archetypeCountBefore = storage.archetypes.count
+
+        commands.entity(entity).addComponent(ComponentA(value: 5))
+        world.update(currentTime: 1)
+
+        let after = try #require(storage.location(of: entity))
+        #expect(after.archetype === before.archetype)
+        #expect(after.row == before.row)
+        #expect(storage.archetypes.count == archetypeCountBefore)
+
+        let columnA = try self.column(of: ComponentA.self, in: after.archetype, storage: storage)
+        #expect(columnA.data[after.row] == ComponentA(value: 5))
+    }
+
+    /// ON: 持っていない型の `removeComponent` は no-op で、Archetype 移動を起こしません。
+    @Test func removeComponentOfAbsentTypeIsNoOp() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+
+        let before = try #require(storage.location(of: entity))
+        let archetypeCountBefore = storage.archetypes.count
+
+        commands.entity(entity).removeComponent(ofType: ComponentB.self)
+        world.update(currentTime: 1)
+
+        let after = try #require(storage.location(of: entity))
+        #expect(after.archetype === before.archetype)
+        #expect(after.row == before.row)
+        #expect(storage.archetypes.count == archetypeCountBefore)
+    }
+
+    /// ON: 同一型への add → remove(正規化で remove、対象型は元々持っていない)は
+    /// 構造変更なしで完了し、Archetype 移動を起こしません。
+    @Test func addThenRemoveSameAbsentTypeCausesNoArchetypeChange() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+
+        let before = try #require(storage.location(of: entity))
+        let archetypeCountBefore = storage.archetypes.count
+
+        commands.entity(entity)
+            .addComponent(ComponentB(text: "temp"))
+            .removeComponent(ofType: ComponentB.self)
+        world.update(currentTime: 1)
+
+        let after = try #require(storage.location(of: entity))
+        #expect(after.archetype === before.archetype)
+        #expect(after.row == before.row)
+        #expect(storage.archetypes.count == archetypeCountBefore)
+    }
+
+    /// ON: `commands.entity(e)` のみ(空 diff)は Archetype 移動も新規 Archetype 生成も
+    /// 起こしません(要件 3-4)。
+    @Test func emptyEntityCommandsCauseNoArchetypeChange() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+
+        let before = try #require(storage.location(of: entity))
+        let archetypeCountBefore = storage.archetypes.count
+
+        _ = commands.entity(entity)
+        world.update(currentTime: 1)
+
+        // 空 diff は diffQueues にすら積まれず、所在・Archetype 数ともに不変です。
+        #expect(storage.diffQueues.isEmpty)
+        let after = try #require(storage.location(of: entity))
+        #expect(after.archetype === before.archetype)
+        #expect(after.row == before.row)
+        #expect(storage.archetypes.count == archetypeCountBefore)
+    }
+
+    /// ON: 同一フレームで diff と despawn が積まれた場合、despawn 済み entity への
+    /// diff 適用は silent skip され、クラッシュしません。
+    @Test func diffForEntityDespawnedInSameFrameIsSilentlySkipped() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        world.update(currentTime: 0)
+
+        commands.entity(entity).addComponent(ComponentB(text: "b"))
+        commands.despawn(entity: entity)
+        world.update(currentTime: 1)
+
+        #expect(storage.location(of: entity) == nil)
+        #expect(storage.diffQueues.isEmpty)
+    }
+
+    /// ON: 同一 Archetype の複数 entity のうち行 0 の entity を移動させたとき、
+    /// swap-remove で行 0 を埋めた entity(filler)の所在・値が正しく補正されます
+    /// (`entityIndex.update(forEntity:)` による補正)。
+    @Test func swapRemoveFillerEntityLocationIsCorrectedAfterMove() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+
+        let first = commands.spawn()
+            .addComponent(ComponentA(value: 10))
+            .id()
+        let second = commands.spawn()
+            .addComponent(ComponentA(value: 20))
+            .id()
+
+        var queryValueForSecond: Int?
+        world.addSystem(.update) { (query: Query<ComponentA>) in
+            queryValueForSecond = query.components(forEntity: second)?.value
+        }
+
+        world.update(currentTime: 0)
+
+        // 2 entity が同一 Archetype の行 0, 1 に入っていることを前提として確認します。
+        let sourceBefore = try #require(storage.location(of: first))
+        #expect(sourceBefore.row == 0)
+        #expect(try #require(storage.location(of: second)).row == 1)
+
+        // 行 0 の entity を移動させ、行 1 の entity が filler として行 0 に落ちます。
+        commands.entity(first).addComponent(ComponentB(text: "moved"))
+        world.update(currentTime: 1)
+
+        // filler(second)の所在が行 0 に補正され、値の解決も正しいままです。
+        let fillerLocation = try #require(storage.location(of: second))
+        #expect(fillerLocation.archetype === sourceBefore.archetype)
+        #expect(fillerLocation.row == 0)
+        let columnA = try self.column(of: ComponentA.self, in: fillerLocation.archetype, storage: storage)
+        #expect(columnA.data[fillerLocation.row] == ComponentA(value: 20))
+        #expect(queryValueForSecond == 20)
+
+        // 移動した entity(first)の所在と値も正しいことを確認します。
+        let movedLocation = try #require(storage.location(of: first))
+        #expect(movedLocation.archetype !== sourceBefore.archetype)
+        let movedColumnA = try self.column(of: ComponentA.self, in: movedLocation.archetype, storage: storage)
+        let movedColumnB = try self.column(of: ComponentB.self, in: movedLocation.archetype, storage: storage)
+        #expect(movedColumnA.data[movedLocation.row] == ComponentA(value: 10))
+        #expect(movedColumnB.data[movedLocation.row] == ComponentB(text: "moved"))
+    }
+
+    /// ON: 単一コンポーネント追加の移動で archetype graph の辺(addEdges / removeEdges)が
+    /// キャッシュされ、2 回目以降の同じ移動で再利用されます(要件 5-1)。
+    @Test func singleComponentMoveCachesArchetypeEdges() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+
+        let first = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .id()
+        let second = commands.spawn()
+            .addComponent(ComponentA(value: 2))
+            .id()
+        world.update(currentTime: 0)
+
+        let source = try #require(storage.location(of: first)).archetype
+
+        commands.entity(first).addComponent(ComponentB(text: "b"))
+        world.update(currentTime: 1)
+
+        // 辺が双方向にキャッシュされます。
+        let idB = storage.typeID(for: ObjectIdentifier(ComponentB.self))
+        let target = try #require(storage.location(of: first)).archetype
+        #expect(source.addEdges[idB] === target)
+        #expect(target.removeEdges[idB] === source)
+
+        // 2 回目の同じ移動では新規 Archetype が生成されません(辺の再利用)。
+        let archetypeCountBefore = storage.archetypes.count
+        commands.entity(second).addComponent(ComponentB(text: "b2"))
+        world.update(currentTime: 2)
+
+        #expect(storage.archetypes.count == archetypeCountBefore)
+        #expect(try #require(storage.location(of: second)).archetype === target)
+    }
+
+    /// ON: 複数差分(remove + add)の複合移動でも所在と値が正しく反映されます。
+    @Test func combinedRemoveAndAddDiffsMoveEntityToCorrectArchetype() throws {
+        let world = World(experimentalOptions: [.archetypeStorage])
+        let storage = try #require(world.worldStorage.archetypeStorageRef)
+        let commands = world.worldStorage.commands
+        let entity = commands.spawn()
+            .addComponent(ComponentA(value: 1))
+            .addComponent(ComponentB(text: "keep"))
+            .id()
+        world.update(currentTime: 0)
+
+        commands.entity(entity)
+            .removeComponent(ofType: ComponentA.self)
+            .addComponent(ComponentC(flag: true))
+        world.update(currentTime: 1)
+
+        let location = try #require(storage.location(of: entity))
+        #expect(location.archetype.key.ids.count == 2)
+        let columnB = try self.column(of: ComponentB.self, in: location.archetype, storage: storage)
+        let columnC = try self.column(of: ComponentC.self, in: location.archetype, storage: storage)
+        #expect(columnB.data[location.row] == ComponentB(text: "keep"))
+        #expect(columnC.data[location.row] == ComponentC(flag: true))
+
+        // A は移動対象外(破棄)なので、移動先に A のカラムはありません。
+        let idA = storage.typeID(for: ObjectIdentifier(ComponentA.self))
+        #expect(location.archetype.column(of: idA) == nil)
+    }
+}

--- a/Tests/ecs-swiftTests/Archetype/SearchedEntityDiffTests.swift
+++ b/Tests/ecs-swiftTests/Archetype/SearchedEntityDiffTests.swift
@@ -252,6 +252,7 @@ struct SearchedEntityDiffTests {
             observedPerFrame.append(values)
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -290,6 +291,7 @@ struct SearchedEntityDiffTests {
             observedPerFrame.append(values)
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
         world.update(currentTime: 1)
 
@@ -315,6 +317,7 @@ struct SearchedEntityDiffTests {
         let entity = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         let before = try #require(storage.location(of: entity))
@@ -340,6 +343,7 @@ struct SearchedEntityDiffTests {
         let entity = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         let before = try #require(storage.location(of: entity))
@@ -363,6 +367,7 @@ struct SearchedEntityDiffTests {
         let entity = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         let before = try #require(storage.location(of: entity))
@@ -388,6 +393,7 @@ struct SearchedEntityDiffTests {
         let entity = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         let before = try #require(storage.location(of: entity))
@@ -413,6 +419,7 @@ struct SearchedEntityDiffTests {
         let entity = commands.spawn()
             .addComponent(ComponentA(value: 1))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         commands.entity(entity).addComponent(ComponentB(text: "b"))
@@ -443,6 +450,7 @@ struct SearchedEntityDiffTests {
             queryValueForSecond = query.components(forEntity: second)?.value
         }
 
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         // 2 entity が同一 Archetype の行 0, 1 に入っていることを前提として確認します。
@@ -484,6 +492,7 @@ struct SearchedEntityDiffTests {
         let second = commands.spawn()
             .addComponent(ComponentA(value: 2))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         let source = try #require(storage.location(of: first)).archetype
@@ -515,6 +524,7 @@ struct SearchedEntityDiffTests {
             .addComponent(ComponentA(value: 1))
             .addComponent(ComponentB(text: "keep"))
             .id()
+        world.setUpWorld()
         world.update(currentTime: 0)
 
         commands.entity(entity)

--- a/Tests/ecs-swiftTests/Archetype/WorldBackend.swift
+++ b/Tests/ecs-swiftTests/Archetype/WorldBackend.swift
@@ -1,0 +1,40 @@
+//
+//  WorldBackend.swift
+//
+//
+//  Created by rrbox on 2026/07/09.
+//
+
+@testable import ECS
+
+/// 新旧ストレージを切り替えて World を構築するテストヘルパです(タスク 7.1)。
+///
+/// `@Test(arguments: WorldBackend.allCases)` に渡すことで、同一テストを
+/// legacy(現行 chunk 実装)と archetype(検証用新実装)の両バックエンドに流せます。
+/// XCTest からも `for backend in WorldBackend.allCases { ... }` で利用できます。
+enum WorldBackend: CaseIterable, CustomStringConvertible {
+    /// 現行実装(chunk ベース)。`World()` と同じです。
+    case legacy
+    /// 新実装(`ExperimentalWorldOptions.archetypeStorage` ON)。
+    case archetype
+
+    /// このバックエンドの World を構築します。
+    func makeWorld() -> World {
+        switch self {
+        case .legacy:
+            return World()
+        case .archetype:
+            return World(experimentalOptions: [.archetypeStorage])
+        }
+    }
+
+    /// テスト出力で引数を判別しやすくするための表示名です。
+    var description: String {
+        switch self {
+        case .legacy:
+            return "legacy"
+        case .archetype:
+            return "archetype"
+        }
+    }
+}

--- a/Tests/ecs-swiftTests/BundleTests.swift
+++ b/Tests/ecs-swiftTests/BundleTests.swift
@@ -9,9 +9,18 @@
 import XCTest
 
 final class BundleTests: XCTestCase {
+    // タスク 7.2: 新旧両バックエンドで実行されます。
+    // 対象 entity 数の検証は chunk 内部(components.data)ではなくイテレーション回数で行います
+    // (新バックエンドでは chunk の SparseSet を使用しないため、挙動ベースの等価な検証に変更)。
     func testAddBundle() {
+        for backend in WorldBackend.allCases {
+            self.runAddBundle(backend: backend)
+        }
+    }
+
+    private func runAddBundle(backend: WorldBackend) {
         var flags = [0]
-        let world = World()
+        let world = backend.makeWorld()
             .addSystem(.startUp) { (commands: Commands) in
                 commands
                     .spawn()
@@ -19,7 +28,11 @@ final class BundleTests: XCTestCase {
             }
             .addSystem(.update) { (query: Query5<TestComponent, TestComponent2, TestComponent3, TestComponent4, TestComponent5>) in
                 flags[0] += 1
-                XCTAssertEqual(query.components.data.count, 1)
+                var matchedEntityCount = 0
+                query.update { _, _, _, _, _ in
+                    matchedEntityCount += 1
+                }
+                XCTAssertEqual(matchedEntityCount, 1)
             }
 
         world.setUpWorld()

--- a/Tests/ecs-swiftTests/CommandsTests.swift
+++ b/Tests/ecs-swiftTests/CommandsTests.swift
@@ -29,8 +29,15 @@ class TestCommand_Despawn: Command {
 }
 
 final class CommandsTests: XCTestCase {
+    // タスク 7.2: 新旧両バックエンドで実行されます(コマンドキューと entity table は共通経路)。
     func testCommands() {
-        let world = World()
+        for backend in WorldBackend.allCases {
+            self.runCommands(backend: backend)
+        }
+    }
+
+    private func runCommands(backend: WorldBackend) {
+        let world = backend.makeWorld()
         let commands = world.worldStorage.commands
 
         let testEntities = [Entity(slot: 0, generation: 0), Entity(slot: 1, generation: 0), Entity(slot: 2, generation: 0)]

--- a/Tests/ecs-swiftTests/EventTests.swift
+++ b/Tests/ecs-swiftTests/EventTests.swift
@@ -75,11 +75,18 @@ func despanedEntitySystem(
     }
 }
 
+// タスク 7.2: 各テストは新旧両バックエンド(WorldBackend.allCases)で実行されます。
 final class EventTests: XCTestCase {
     func testEvent() {
+        for backend in WorldBackend.allCases {
+            self.runEvent(backend: backend)
+        }
+    }
+
+    private func runEvent(backend: WorldBackend) {
         print()
 
-        let world = World()
+        let world = backend.makeWorld()
             .addEventStreamer(eventType: TestEvent.self)
             .addSystem(.update, testEvent(events:eventWriter:commands:currentTime:))
             .addSystem(.startUp, setUp(eventWriter:))
@@ -96,9 +103,15 @@ final class EventTests: XCTestCase {
     }
 
     func testEventStream() {
+        for backend in WorldBackend.allCases {
+            self.runEventStream(backend: backend)
+        }
+    }
+
+    private func runEventStream(backend: WorldBackend) {
         var flags = [0, 0, 0, 0]
 
-        let world = World()
+        let world = backend.makeWorld()
             .addEventStreamer(eventType: TestEvent.self)
             .addSystem(.startUp) { (eventWriter: EventWriter<TestEvent>) in
                 eventWriter.send(.init(name: "test event"))
@@ -129,10 +142,16 @@ final class EventTests: XCTestCase {
     }
 
     func testSendTwoEventsInOneUpdate() {
+        for backend in WorldBackend.allCases {
+            self.runSendTwoEventsInOneUpdate(backend: backend)
+        }
+    }
+
+    private func runSendTwoEventsInOneUpdate(backend: WorldBackend) {
         var receivedEventCounts = [0, 0]
         var flags = [0, 0, 0]
 
-        let world = World()
+        let world = backend.makeWorld()
             .addEventStreamer(eventType: TestEvent.self)
             .addSystem(.startUp, { (eventWriter: EventWriter<TestEvent>) in
                 eventWriter.send(.init(name: "event 1"))
@@ -160,9 +179,15 @@ final class EventTests: XCTestCase {
     }
 
     func testSystemExecutesOnceWithTwoEvents() {
+        for backend in WorldBackend.allCases {
+            self.runSystemExecutesOnceWithTwoEvents(backend: backend)
+        }
+    }
+
+    private func runSystemExecutesOnceWithTwoEvents(backend: WorldBackend) {
         var executionCount = 0
 
-        let world = World()
+        let world = backend.makeWorld()
             .addEventStreamer(eventType: TestEvent.self)
             .addSystem(.startUp) { (eventWriter: EventWriter<TestEvent>) in
                 eventWriter.send(.init(name: "event 1"))
@@ -182,8 +207,14 @@ final class EventTests: XCTestCase {
     }
 
     func testRemovedOnEvent() {
+        for backend in WorldBackend.allCases {
+            self.runRemovedOnEvent(backend: backend)
+        }
+    }
+
+    private func runRemovedOnEvent(backend: WorldBackend) {
         var flags = [0, 0, 0]
-        let world = World()
+        let world = backend.makeWorld()
             .addEventStreamer(eventType: TestEvent.self)
             .addState(initialState: EventTestState.stateA, states: [
                 .stateA, .stateB, .stateC
@@ -218,9 +249,15 @@ final class EventTests: XCTestCase {
     }
 
     func testRemovedOnStackEvent() {
+        for backend in WorldBackend.allCases {
+            self.runRemovedOnStackEvent(backend: backend)
+        }
+    }
+
+    private func runRemovedOnStackEvent(backend: WorldBackend) {
         var flagsA = [0, 0]
         var flagsB = [0, 0]
-        let world = World()
+        let world = backend.makeWorld()
             .addEventStreamer(eventType: TestEvent.self)
             .addState(initialState: EventTestState.stateA, states: [
                 .stateA, .stateB
@@ -259,8 +296,14 @@ final class EventTests: XCTestCase {
     }
 
     func testRemovedOnInactiveEvent() {
+        for backend in WorldBackend.allCases {
+            self.runRemovedOnInactiveEvent(backend: backend)
+        }
+    }
+
+    private func runRemovedOnInactiveEvent(backend: WorldBackend) {
         var flags = [0, 0]
-        let world = World()
+        let world = backend.makeWorld()
             .addEventStreamer(eventType: TestEvent.self)
             .addState(initialState: EventTestState.stateA, states: [
                 .stateA, .stateB

--- a/Tests/ecs-swiftTests/StartUpTest.swift
+++ b/Tests/ecs-swiftTests/StartUpTest.swift
@@ -14,10 +14,12 @@ struct Test {
         case inGame
     }
 
+    // タスク 7.2: 各テストは新旧両バックエンド(WorldBackend.allCases)で実行されます。
     @MainActor
-    @Test func startUpSystems() async throws {
+    @Test(arguments: WorldBackend.allCases)
+    func startUpSystems(backend: WorldBackend) async throws {
         var flags = [0, 0, 0, 0, 0, 0]
-        let world = World()
+        let world = backend.makeWorld()
             .addSystem(.preStartUp) { (_: Commands) in // 1
                 flags[0] += 1
                 #expect(flags == [1, 0, 0, 0, 0, 0])
@@ -52,9 +54,10 @@ struct Test {
     }
 
     @MainActor
-    @Test func stateDidEnter() async throws {
+    @Test(arguments: WorldBackend.allCases)
+    func stateDidEnter(backend: WorldBackend) async throws {
         var flags = [0, 0, 0, 0]
-        let world = World()
+        let world = backend.makeWorld()
             .addState(initialState: StateCase.title, states: [.title, .inGame])
             .addSystem(.didEnter(StateCase.title), { (_ :Commands) in // 2
                 flags[1] += 1

--- a/Tests/ecs-swiftTests/StateTests.swift
+++ b/Tests/ecs-swiftTests/StateTests.swift
@@ -16,10 +16,12 @@ struct StateTests {
         case pause
     }
 
-    @Test func transitionState() async throws {
+    // タスク 7.2: 各テストは新旧両バックエンド(WorldBackend.allCases)で実行されます。
+    @Test(arguments: WorldBackend.allCases)
+    func transitionState(backend: WorldBackend) async throws {
         var flags: [Int] = .init(repeating: 0, count: 6)
 
-        let world = World()
+        let world = backend.makeWorld()
             .addState(initialState: StateCase.title, states: [.title, .inGame, .pause])
             .addSystem(.didEnter(StateCase.title)) { (currentTime: Resource<CurrentTime>) in
                 flags[0] += 1
@@ -63,10 +65,11 @@ struct StateTests {
     }
 
     // case 1: `push` in start up
-    @Test func pushStateInStartUp() async throws {
+    @Test(arguments: WorldBackend.allCases)
+    func pushStateInStartUp(backend: WorldBackend) async throws {
         var flags = [Int](repeating: 0, count: 6)
 
-        let world = World()
+        let world = backend.makeWorld()
             .addState(initialState: StateCase.inGame, states: [.inGame, .pause])
             .addSystem(.onStackUpdate(StateCase.inGame)) { (currentTime: Resource<CurrentTime>) in
                 flags[0] += 1
@@ -113,10 +116,11 @@ struct StateTests {
     }
 
     // case 2: push in `update`
-    @Test func pushStateInUpdate() async throws {
+    @Test(arguments: WorldBackend.allCases)
+    func pushStateInUpdate(backend: WorldBackend) async throws {
         var flags = [Int](repeating: 0, count: 6)
 
-        let world = World()
+        let world = backend.makeWorld()
             .addState(initialState: StateCase.inGame, states: [.inGame, .pause])
             .addSystem(.onStackUpdate(StateCase.inGame)) { (currentTime: Resource<CurrentTime>) in
                 flags[0] += 1
@@ -165,10 +169,11 @@ struct StateTests {
     // case 3: pop in `update`
     //
     // - start up で pop するケースは存在しない.
-    @Test func popStateInUpdate() async throws {
+    @Test(arguments: WorldBackend.allCases)
+    func popStateInUpdate(backend: WorldBackend) async throws {
         var flags = [Int](repeating: 0, count: 2)
 
-        let world = World()
+        let world = backend.makeWorld()
             .addState(initialState: StateCase.inGame, states: [.inGame, .pause])
             .addSystem(.startUp, { (state: State<StateCase>,
                                     currentTime: Resource<CurrentTime>) in

--- a/Tests/ecs-swiftTests/UpdateSystemTests.swift
+++ b/Tests/ecs-swiftTests/UpdateSystemTests.swift
@@ -20,12 +20,15 @@ func mySystem2(query: Query<TestComponent>) {
 }
 
 final class UpdateSystemTests: XCTestCase {
+    // タスク 7.2: 新旧両バックエンドで実行されます。
     func testUpdate() {
-        let world = World()
-            .addSystem(.update, mySystem(commands:))
-            .addSystem(.update, mySystem2(query:))
+        for backend in WorldBackend.allCases {
+            let world = backend.makeWorld()
+                .addSystem(.update, mySystem(commands:))
+                .addSystem(.update, mySystem2(query:))
 
-        world.update(currentTime: 0)
-        world.update(currentTime: 0)
+            world.update(currentTime: 0)
+            world.update(currentTime: 0)
+        }
     }
 }

--- a/Tests/ecs-swiftTests/WorldTests.swift
+++ b/Tests/ecs-swiftTests/WorldTests.swift
@@ -9,7 +9,10 @@ import XCTest
 import ECS
 
 final class WorldTests: XCTestCase {
+    // タスク 7.2: 新旧両バックエンドで実行されます。
     func testWorld() {
-        _ = World()
+        for backend in WorldBackend.allCases {
+            _ = backend.makeWorld()
+        }
     }
 }

--- a/Tests/ecs-swiftTests/ecs_swiftTests.swift
+++ b/Tests/ecs-swiftTests/ecs_swiftTests.swift
@@ -45,12 +45,11 @@ func update4(query: Query<Text>) {
 }
 
 final class ecs_swiftTests: XCTestCase {
-    // entity: 20000
-    // set up: 1
-    // update: 1
-    // 0.00478 s
-    func testPerformance() {
-        let world = World()
+    // タスク 7.2: `measure` はテストメソッドごとに 1 回しか呼べないため、
+    // ループではなくバックエンドごとのテストメソッドで新旧両方を実行します。
+
+    private func runPerformance(backend: WorldBackend) {
+        let world = backend.makeWorld()
             .addSystem(.startUp, entitycreate(commands:))
             .addSystem(.update, update(query:))
         world.setUpWorld()
@@ -63,12 +62,8 @@ final class ecs_swiftTests: XCTestCase {
         }
     }
 
-    // entity: 20000
-    // set up: 1
-    // update: 4
-    // 0.0158 s -> およそ 4 倍
-    func testUpdate4Performance() {
-        let world = World()
+    private func runUpdate4Performance(backend: WorldBackend) {
+        let world = backend.makeWorld()
             .addSystem(.startUp, entitycreate(commands:))
             .addSystem(.update, update(query:))
             .addSystem(.update, update2(query:))
@@ -82,5 +77,29 @@ final class ecs_swiftTests: XCTestCase {
         measure {
             world.update(currentTime: 0)
         }
+    }
+
+    // entity: 20000
+    // set up: 1
+    // update: 1
+    // 0.00478 s
+    func testPerformance() {
+        self.runPerformance(backend: .legacy)
+    }
+
+    func testPerformanceArchetype() {
+        self.runPerformance(backend: .archetype)
+    }
+
+    // entity: 20000
+    // set up: 1
+    // update: 4
+    // 0.0158 s -> およそ 4 倍
+    func testUpdate4Performance() {
+        self.runUpdate4Performance(backend: .legacy)
+    }
+
+    func testUpdate4PerformanceArchetype() {
+        self.runUpdate4Performance(backend: .archetype)
     }
 }


### PR DESCRIPTION
## 概要

GitHub issue #130「Archetype ECS (SoA)」の**検証用(Spike)実装**です。**マージしません**(検証完了後に close し、結果を反映した本実装を別課題として新設します)。

現行の AoS(共有参照箱 + Chunk ブロードキャスト)構成に対し、コンポーネントを型集合(Archetype)ごとの SoA カラムに整列格納する新コアストレージを、World 初期化時の内部オプション(`ExperimentalWorldOptions.archetypeStorage`、internal)による新旧並走の形で実装しました。

- 要件定義・技術設計・検証記録: `dev_docs/archetype_ecs/`(requirements.md / design.md / work_log.md)
- 公開 API は不変(要件 3)。既存 entity への操作のみ内部を record 直接操作から差分トランザクション方式に変更(折衷方針)

## 合格基準チェックリスト

### 実現性基準

- [x] **型順補正の成立**(要件 2-3): `Query2<A, B>` / `Query2<B, A>` が同一 entity 集合を返すことをテストで確認(`ArchetypeQueryTests` / `ArchetypeQueryNTests`)
- [x] **`@testable import` + release ビルドの成立**: `swift test -c release` で追加フラグなしに成立(タスク 1.1 で検証、ベンチ実行でも再確認)
- [x] **`unowned` EntityLocation の寿命問題なし**: Archetype は `ArchetypeStorageRef` と同寿命(削除・GC なし、設計のノンゴールとして明示)。全テスト・ベンチマーク実行でクラッシュなし
- [x] **既存コアテストのオプション ON 通過**(要件 4-3): CommandsTests / EventTests / StartUpTest / StateTests / UpdateSystemTests / WorldTests / BundleTests / ecs_swiftTests を新旧両バックエンドで実行し全通過。除外(Filtered 使用・カスタム EntityCommand 使用・重複型 Query 使用・chunk 内部検証・World 非構築)の一覧と根拠は `dev_docs/archetype_ecs/work_log.md` セッション4 参照

### パフォーマンス基準(ベンチ3シナリオで新実装が同等以上)

計測: 2026-07-11、release 構成、5 回実行の中央値。`RUN_BENCHMARKS=1 swift test -c release --filter Benchmarks`

- [x] **シナリオ3(空コマンド × N)**: 全 N で新実装が 2.3〜2.6 倍高速(要件 3-4 の効果)
- [ ] **シナリオ1(イテレーション、Query3 × 100 フレーム)**: 部分達成 — N=10^5 で 10% 高速だが、N=10^3 で 4%・N=10^4 で 7% 低速

  | N | legacy | archetype |
  |---|---|---|
  | 10^3 | 28.99ms | 30.27ms |
  | 10^4 | 288.6ms | 307.7ms |
  | 10^5 | 2769.7ms | **2503.0ms** |

- [ ] **シナリオ2(spawn/despawn、登録 Query 数 k = 1/10/50)**: 部分達成 — **要件 5-1(Query 数非比例)は明確に実証**(新実装は k によらずほぼ一定)。ただし k=1 では約 2.3 倍低速

  | N=10^5 | k=1 | k=10 | k=50 |
  |---|---|---|---|
  | legacy | 120.8ms | 259.3ms | 902.9ms |
  | archetype | 276.4ms | 252.8ms | 252.9ms |

## 検証から得られた知見(本実装への引き継ぎ事項)

1. **spawn 経路の staging 変換コスト**: k=1 の spawn/despawn で新実装が遅いのは、折衷方針で維持した「EntityRecordRef staging → カラム変換」の固定コスト。本実装では spawn 経路の record 非依存化(具象課題1の案B)で削減余地あり
2. **小規模 N のイテレーション**: 4〜7% の低速はアーキタイプマッチのループ構造オーバーヘッドと推測。大規模では SoA の局所性が勝る(N=10^5 で逆転)。カラムのポインタ化(第二段階)で改善見込み
3. 実装上の設計判断・課題の時系列は `dev_docs/archetype_ecs/`(meta_issues_log.md / impl_issues_log.md / tasks.md の Implementation Notes)に記録済み

## テスト

- フルスイート green(2026-07-11 確認): コアターゲット swift-testing 120+ / XCTest 21 + プラグインターゲット
- Benchmarks は CI では環境変数ゲートにより skip(即 return)

## 関連

- Closes しない(検証用): #130 の検証結果報告
- 検証後: 本 PR を close し、本実装課題を新設予定
